### PR TITLE
Specify optional `asyncio` requirement properly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[metadata]
+requires-dist =
+    asyncio; python_version == '3.3'
+
 [bdist_wheel]
 python-tag=py33
 

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,27 @@
 import os
 import sys
-import setuptools
+from setuptools import setup
 
 # Avoid polluting the .tar.gz with ._* files under Mac OS X
 os.putenv('COPYFILE_DISABLE', 'true')
 
 root = os.path.dirname(__file__)
 
-# Prevent distutils from complaining that a standard file wasn't found
-README = os.path.join(root, 'README')
-if not os.path.exists(README):
-    os.symlink(README + '.rst', README)
-
 description = "An implementation of the WebSocket Protocol (RFC 6455)"
 
-with open(os.path.join(root, 'README'), encoding='utf-8') as f:
+with open(os.path.join(root, 'README.rst'), encoding='utf-8') as f:
     long_description = '\n\n'.join(f.read().split('\n\n')[1:])
 
-with open(os.path.join(root, 'websockets', 'version.py'), encoding='utf-8') as f:
+with open(os.path.join(root, 'websockets', 'version.py'),
+          encoding='utf-8') as f:
     exec(f.read())
 
-py_version = sys.version_info[:2]
-
-if py_version < (3, 3):
+if sys.version_info < (3, 3):
     raise Exception("websockets requires Python >= 3.3.")
 
-setuptools.setup(
+setup(
     name='websockets',
-    version=version,
+    version=version,  # noqa
     author='Aymeric Augustin',
     author_email='aymeric.augustin@m4x.org',
     url='https://github.com/aaugustin/websockets',
@@ -37,7 +31,7 @@ setuptools.setup(
     packages=[
         'websockets',
     ],
-    install_requires=['asyncio'] if py_version == (3, 3) else [],
+    extras_require={':python_version=="3.3"': ['asyncio']},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",


### PR DESCRIPTION
Previously, the runtime configuration for this would not work with wheels, which are static archives (and their `setup.py` is only run at build time, so is only valid for the python version that `setup.py` was run with). This should fix that problem for wheels, i.e #25.

[This part of the wheel docs](http://wheel.readthedocs.org/en/latest/#defining-conditional-dependencies) explains conditional dependencies but for the _next_ release of wheel, 0.24.0, not the current ATOW. The `[metadata]` section in `setup.cfg` will work to correctly mark the cond. dep till 0.24 is released.

websockets is not a universal wheel either, it relies on python 3.3+, so I changed `setup.cfg` to reflect this. [See this part of the wheels docs](http://wheel.readthedocs.org/en/latest/#defining-the-python-version)
