### PR TITLE
Close connection properly when the socket dies.

### DIFF
--- a/websockets/test_client_server.py
+++ b/websockets/test_client_server.py
@@ -155,8 +155,8 @@ class ClientServerTests(unittest.TestCase):
         self.assertEqual(reply, "Hello!")
         self.stop_client()
 
-        # Connection ends with a protocol error.
-        self.assertEqual(self.client.close_code, 1002)
+        # Connection ends with an abnormal closure.
+        self.assertEqual(self.client.close_code, 1006)
 
 
 @unittest.skipUnless(os.path.exists(testcert), "test certificate is missing")


### PR DESCRIPTION
This avoids flooding logs with messages output by asyncio:
"socket.send() raised exception."

Fix #23 (hopefully).
