### PR TITLE
Prevent incomplete task leak in recv.

### DIFF
--- a/websockets/protocol.py
+++ b/websockets/protocol.py
@@ -157,12 +157,14 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
             pass
 
         # Wait for a message until the connection is closed
-        next_message = asyncio.Task(self.messages.get())
+        next_message = asyncio.async(self.messages.get())
         done, pending = yield from asyncio.wait(
                 [next_message, self.worker],
                 return_when=asyncio.FIRST_COMPLETED)
         if next_message in done:
             return next_message.result()
+        else:
+            next_message.cancel()
 
     @asyncio.coroutine
     def send(self, data):


### PR DESCRIPTION
If `self.worker` completes before `next_message`, then `next_message` will remain scheduled forever. This is a pr to explicitly cancel the coroutine if the worker completes. A new `next_message` will naturally be scheduled if/when recv is called again. 

It also uses `asyncio.async` instead of `Task` in accordance with the [docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.Task).
