### PR TITLE
Add Digest Authentication to client

### DIFF
--- a/src/websockets/__init__.py
+++ b/src/websockets/__init__.py
@@ -12,6 +12,7 @@ from .version import version as __version__  # noqa
 
 __all__ = [
     "AbortHandshake",
+    "AuthenticationRequest",
     "basic_auth_protocol_factory",
     "BasicAuthWebSocketServerProtocol",
     "connect",

--- a/src/websockets/exceptions.py
+++ b/src/websockets/exceptions.py
@@ -20,6 +20,7 @@
             * :exc:`InvalidParameterValue`
         * :exc:`AbortHandshake`
         * :exc:`RedirectHandshake`
+        * :exc:`AuthenticationRequest`
     * :exc:`InvalidState`
     * :exc:`InvalidURI`
     * :exc:`PayloadTooBig`
@@ -53,6 +54,7 @@ __all__ = [
     "InvalidParameterValue",
     "AbortHandshake",
     "RedirectHandshake",
+    "AuthenticationRequest",
     "InvalidState",
     "InvalidURI",
     "PayloadTooBig",
@@ -325,6 +327,20 @@ class RedirectHandshake(InvalidHandshake):
     def __str__(self) -> str:
         return f"redirect to {self.uri}"
 
+
+class AuthenticationRequest(InvalidHandshake):
+    """ 
+    Raised when a 401 Unauthorized response is received.
+    Another implementation detail, to allow e.g., Digest authentication
+
+    """
+    def __init__(self, details : str) -> None:
+        self.authresponse = details
+
+    def __str__(self) -> str:
+        return f"WWW-Authenticate: {self.authresponse}"
+            
+    
 
 class InvalidState(WebSocketException, AssertionError):
     """


### PR DESCRIPTION
Uses the python3-digest package to decode the HTTP digest authorisation challenge
and create an appropriate extra header to authenticate.

This addresses issue #784 -- it's really a straw-man PR, as a start at how one might do it. I'm sure there are better ways...