### PR TITLE
Fix docstring of parse_uri to reflect the exception type raised

### DIFF
--- a/src/websockets/uri.py
+++ b/src/websockets/uri.py
@@ -49,7 +49,8 @@ def parse_uri(uri: str) -> WebSocketURI:
     """
     Parse and validate a WebSocket URI.
 
-    :raises ValueError: if ``uri`` isn't a valid WebSocket URI.
+    :raises ~websockets.exceptions.InvalidURI: if ``uri`` isn't a valid
+        WebSocket URI.
 
     """
     parsed = urllib.parse.urlparse(uri)


### PR DESCRIPTION
It doesn't raise a ValueError, but an InvalidURI error (see below). If we want the exception type to be a ValueError as well, you could make InvalidURI inherit from ValueError as well as WebSocketException. But just changing the doc seems like the right fix here.

```
>>> from websockets.uri import parse_uri
>>> parse_uri('foo://example.com')
Traceback (most recent call last):
  File "/home/ben/w/websockets/src/websockets/uri.py", line 58, in parse_uri
    assert parsed.scheme in ["ws", "wss"]
AssertionError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ben/w/websockets/src/websockets/uri.py", line 63, in parse_uri
    raise exceptions.InvalidURI(uri) from exc
websockets.exceptions.InvalidURI: foo://example.com isn't a valid URI
>>> import sys
>>> exc = sys.last_value
>>> isinstance(exc, ValueError)
False
```