### PR TITLE
Use selectors instead of select.poll in sync.WebSocket Server for multi-platform support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ source = [
 exclude_lines = [
     "except ImportError:",
     "if self.debug:",
+    "if sys.platform != \"win32\":",
     "pragma: no cover",
     "raise AssertionError",
     "raise NotImplementedError",


### PR DESCRIPTION
For a senior-level university network apps design course, my students were using the threaded version of `WebSocketServer` as part of their final project. While the project required their work to run successfully in containers on Linux, many of them use Windows for their development workstation. We discovered that `serve_forever` throws an error at startup on Windows due to the use of `select.poll` as the means to block while waiting for incoming socket connections. The documentation for `poll` indicates that it is not supported on all platforms, and apparently Windows is one such platform.

I patched `WebSocketServer` to instead use `selectors.DefaultSelector` which determines the best supported mechanism for I/O multiplexing on the runtime platform. The functionality is the same, but it works on a wider range of platforms.

After switching to `selectors.DefaultSelector`, I discovered that Windows also doesn't support I/O multiplexing using pipes or files -- only sockets. I removed the use of `os.pipe` for the shutdown mechanism. It was redundant anyway -- simply closing the listener socket in the `shutdown` method is sufficient to cause the selector to return. Subsequently, the call to `socket.accept` (on the closed listener socket) causes the loop in `serve_forever` to terminate as expected.

I tested the change on Windows, Mac OS X, and a Linux container, and it seems that it correctly supports all three platforms.