### PR TITLE
Create GitHub release when pushing tag.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -64,18 +64,25 @@ jobs:
       with:
         path: wheelhouse/*.whl
 
-  upload_pypi:
-    name: Upload to PyPI
+  release:
+    name: Release
     needs:
       - sdist
       - wheels
     runs-on: ubuntu-latest
+    # Don't release when running the workflow manually from GitHub's UI.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v3
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Create GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create ${{ github.ref_name }} --notes "See https://websockets.readthedocs.io/en/stable/project/changelog.html for details."


### PR DESCRIPTION
Fix #1347.