### PR TITLE
Add path to server.py 'hello' function

### DIFF
--- a/example/quickstart/server.py
+++ b/example/quickstart/server.py
@@ -3,7 +3,7 @@
 import asyncio
 import websockets
 
-async def hello(websocket):
+async def hello(websocket, path):
     name = await websocket.recv()
     print(f"<<< {name}")
 


### PR DESCRIPTION
For me at least, on windows, I constantly get the server error
`Error in connection handler
Traceback (most recent call last):
  File "F:\Applications\Files\Python\lib\site-packages\websockets\legacy\server.py", line 293, in handler
    await self.ws_handler(self, path)
TypeError: hello() takes 1 positional argument but 2 were given`
The client also errors and is unable to receive, as the websocket closes.
My pull request fixes this