### PR TITLE
Remove the unused `asyncio` import in `README.rst` in the `threading` example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,6 @@ Here's how a client sends and receives messages with the ``threading`` API:
 
     #!/usr/bin/env python
 
-    import asyncio
     from websockets.sync.client import connect
 
     def hello():


### PR DESCRIPTION
Please let me know if I'm missing something making this import useful in this code snippet.