### PR TITLE
fix: add `WebSocketClientProtocol` and `connect` to all for linters

### DIFF
--- a/src/websockets/client.py
+++ b/src/websockets/client.py
@@ -41,7 +41,7 @@ from .utils import accept_key, generate_key
 from .legacy.client import *  # isort:skip  # noqa: I001
 
 
-__all__ = ["ClientProtocol"]
+__all__ = ["ClientProtocol", "WebSocketClientProtocol", "connect"]
 
 
 class ClientProtocol(Protocol):


### PR DESCRIPTION
With this linters and mypy work better with websockets when importing these such as:
```
from websockets.client import connect, WebSocketClientProtocol
```