### PR TITLE
Allow plain integers as HTTP status codes

### DIFF
--- a/src/websockets/legacy/server.py
+++ b/src/websockets/legacy/server.py
@@ -217,6 +217,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                         ),
                     )
 
+                status = http.HTTPStatus(status)
                 headers.setdefault("Date", email.utils.formatdate(usegmt=True))
                 if self.server_header is not None:
                     headers.setdefault("Server", self.server_header)

--- a/tests/legacy/test_client_server.py
+++ b/tests/legacy/test_client_server.py
@@ -543,6 +543,17 @@ class CommonClientServerTests:
         with contextlib.closing(response):
             self.assertEqual(response.code, 200)
 
+    class ProcessRequestOKServerProtocolNumeric(WebSocketServerProtocol):
+        async def process_request(self, path, request_headers):
+            return 200, [], b"OK\n"
+
+    @with_server(create_protocol=ProcessRequestOKServerProtocolNumeric)
+    def test_numeric_response_code(self):
+        response = self.loop.run_until_complete(self.make_http_request("/"))
+
+        with contextlib.closing(response):
+            self.assertEqual(response.code, 200)
+
     class LegacyProcessRequestOKServerProtocol(WebSocketServerProtocol):
         def process_request(self, path, request_headers):
             return http.HTTPStatus.OK, [], b"OK\n"


### PR DESCRIPTION
Since an IntEnum is largely equivalent to the corresponding integer, allow HTTP status codes to be specified as (eg) `200` rather than `http.HTTPStatus.OK`.