### PR TITLE
Only send pong if OPEN.

### DIFF
--- a/src/websockets/protocol.py
+++ b/src/websockets/protocol.py
@@ -630,8 +630,9 @@ class Protocol:
         elif frame.opcode is OP_PING:
             # 5.5.2. Ping: "Upon receipt of a Ping frame, an endpoint MUST
             # send a Pong frame in response"
-            pong_frame = Frame(OP_PONG, frame.data)
-            self.send_frame(pong_frame)
+            if self.state is OPEN:
+                pong_frame = Frame(OP_PONG, frame.data)
+                self.send_frame(pong_frame)
 
         elif frame.opcode is OP_PONG:
             # 5.5.3 Pong: "A response to an unsolicited Pong frame is not


### PR DESCRIPTION
If the server sends a message and then closes the connection, it's possible for the client to fail to `recv()` the message due to an attempt to send a pong message during the CLOSING state. The following is printed:

```
ERROR:websockets.client:parser failed
Traceback (most recent call last):
  File "/tmp/throwaway-txYF/lib/python3.10/site-packages/websockets/protocol.py", line 550, in parse
    self.recv_frame(frame)
  File "/tmp/throwaway-txYF/lib/python3.10/site-packages/websockets/protocol.py", line 634, in recv_frame
    self.send_frame(pong_frame)
  File "/tmp/throwaway-txYF/lib/python3.10/site-packages/websockets/protocol.py", line 693, in send_frame
    raise InvalidState(
websockets.exceptions.InvalidState: cannot write to a WebSocket in the CLOSING state
```

I found that modifying `websockets/protocol.py` to only send a pong message during the OPEN state allowed me to .recv() the message in this case.