### PR TITLE
Fix wrong RFC number

### DIFF
--- a/src/websockets/legacy/client.py
+++ b/src/websockets/legacy/client.py
@@ -599,7 +599,7 @@ class Connect:
                     yield protocol
             except Exception:
                 # Add a random initial delay between 0 and 5 seconds.
-                # See 7.2.3. Recovering from Abnormal Closure in RFC 6544.
+                # See 7.2.3. Recovering from Abnormal Closure in RFC 6455.
                 if backoff_delay == self.BACKOFF_MIN:
                     initial_delay = random.random() * self.BACKOFF_INITIAL
                     self.logger.info(

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -714,7 +714,7 @@ class CloseTests(ProtocolTestCase):
     """
     Test close frames.
 
-    See RFC 6544:
+    See RFC 6455:
 
     5.5.1. Close
     7.1.6.  The WebSocket Connection Close Reason
@@ -994,7 +994,7 @@ class CloseTests(ProtocolTestCase):
 
 class PingTests(ProtocolTestCase):
     """
-    Test ping. See 5.5.2. Ping in RFC 6544.
+    Test ping. See 5.5.2. Ping in RFC 6455.
 
     """
 
@@ -1153,7 +1153,7 @@ class PingTests(ProtocolTestCase):
 
 class PongTests(ProtocolTestCase):
     """
-    Test pong frames. See 5.5.3. Pong in RFC 6544.
+    Test pong frames. See 5.5.3. Pong in RFC 6455.
 
     """
 
@@ -1298,7 +1298,7 @@ class FailTests(ProtocolTestCase):
     """
     Test failing the connection.
 
-    See 7.1.7. Fail the WebSocket Connection in RFC 6544.
+    See 7.1.7. Fail the WebSocket Connection in RFC 6455.
 
     """
 
@@ -1321,7 +1321,7 @@ class FragmentationTests(ProtocolTestCase):
     """
     Test message fragmentation.
 
-    See 5.4. Fragmentation in RFC 6544.
+    See 5.4. Fragmentation in RFC 6455.
 
     """
 


### PR DESCRIPTION
While studying the websockets source code, I found an incorrect RFC number in the comments and test docstrings.

- Incorrect: [RFC 6544](https://datatracker.ietf.org/doc/html/rfc6544) TCP Candidates with Interactive Connectivity Establishment (ICE)
- Correct: [RFC 6455](https://datatracker.ietf.org/doc/html/rfc6455) The WebSocket Protocol

I did this keyword search and fixed everything.

I truly appreciate your efforts in maintaining this fantastic library!