### PR TITLE
process_request raise ConnectionClosedError

### DIFF
--- a/src/websockets/legacy/client.py
+++ b/src/websockets/legacy/client.py
@@ -60,7 +60,7 @@ class WebSocketClientProtocol(WebSocketCommonProtocol):
     :class:`WebSocketClientProtocol` provides :meth:`recv` and :meth:`send`
     coroutines for receiving and sending messages.
 
-    It supports asynchronous iteration to receive incoming messages::
+    It supports asynchronous iteration to receive messages::
 
         async for message in websocket:
             await process(message)

--- a/src/websockets/legacy/server.py
+++ b/src/websockets/legacy/server.py
@@ -649,9 +649,7 @@ class WebSocketServer:
     """
     WebSocket server returned by :func:`serve`.
 
-    This class provides the same interface as :class:`~asyncio.Server`,
-    notably the :meth:`~asyncio.Server.close`
-    and :meth:`~asyncio.Server.wait_closed` methods.
+    This class mirrors the API of :class:`~asyncio.Server`.
 
     It keeps track of WebSocket connections in order to close them properly
     when shutting down.


### PR DESCRIPTION
An empty bytes data response raises a ConnectionClosedError to a process_request.