### PR TITLE
Verify if is a websocket connection

### DIFF
--- a/src/websockets/sync/server.py
+++ b/src/websockets/sync/server.py
@@ -516,14 +516,8 @@ def serve(
             return
 
         try:
-            protocol.logger.error(connection.__dict__.get('request').headers
-                                  , exc_info=True)
-            protocol.logger.error(is_websocket(connection)
-                                  , exc_info=True)
             if is_websocket(connection):
                 handler(connection)
-            else:
-                connection.close()
         except Exception:
             protocol.logger.error("connection handler failed", exc_info=True)
             connection.close(CloseCode.INTERNAL_ERROR)


### PR DESCRIPTION
Now, every HTTP request is handled as if it were a WebSocket connection. However, when an HTTP request is made and is expected to close the connection, an error arises because it is not supposed to receive an HTTP connection in the handler.

This PR verifies if it is actually a WebSocket connection before handling it.