### PR TITLE
docs: Correct the example for "Starting a server" in the API reference

### DIFF
--- a/docs/faq/server.rst
+++ b/docs/faq/server.rst
@@ -300,7 +300,8 @@ Here's how to adapt the example just above::
 
         server = await websockets.serve(echo, "localhost", 8765)
         await stop
-        await server.close(close_connections=False)
+        server.close(close_connections=False)
+        await server.wait_closed()
 
 How do I implement a health check?
 ----------------------------------

--- a/src/websockets/legacy/server.py
+++ b/src/websockets/legacy/server.py
@@ -899,7 +899,8 @@ class Serve:
 
         server = await serve(...)
         await stop
-        await server.close()
+        server.close()
+        await server.wait_closed()
 
     :func:`serve` can be used as an asynchronous context manager. Then, the
     server is shut down automatically when exiting the context::


### PR DESCRIPTION
It seems that `server.close()` is not an `async` function, so I changed
```python
await server.close()
```
to
```python
server.close()
await server.wait_closed()
```
in the API reference.