### PR TITLE
Fix the issue of redirecting from ws to wss.

### DIFF
--- a/src/websockets/legacy/client.py
+++ b/src/websockets/legacy/client.py
@@ -573,6 +573,10 @@ class Connect:
                 *factory.args,
                 **dict(factory.keywords, host=new_wsuri.host, port=new_wsuri.port),
             )
+            # Fix the issue of "The plain HTTP request was sent to HTTPS port" 
+            # caused by forgetting to enable SSL after redirecting from ws to wss.
+            if new_wsuri.secure:
+                self._create_connection.keywords["ssl"] = True
             # Replace the host and port argument passed to create_connection.
             self._create_connection = functools.partial(
                 self._create_connection.func,


### PR DESCRIPTION
I found that when configuring our company's Apache server, redirecting ws requests to wss and using this websocket library for connection would result in the error "The plain HTTP request was sent to HTTPS port". After using Wireshark for packet capture, I found that this library did not properly configure SSL. After DEBUG, I confirmed that the problem occurred in the 'handle_redirect' function: 'create_connection' requires the correct use of the SSL keyword.