### PR TITLE
docs(nginx): Fix a typo

### DIFF
--- a/docs/howto/nginx.rst
+++ b/docs/howto/nginx.rst
@@ -17,9 +17,9 @@ Save this app to ``app.py``:
 .. literalinclude:: ../../example/deployment/nginx/app.py
     :emphasize-lines: 21,23
 
-We'd like to nginx to connect to websockets servers via Unix sockets in order
-to avoid the overhead of TCP for communicating between processes running in
-the same OS.
+We'd like nginx to connect to websockets servers via Unix sockets in order to
+avoid the overhead of TCP for communicating between processes running in the
+same OS.
 
 We start the app with :func:`~websockets.server.unix_serve`. Each server
 process listens on a different socket thanks to an environment variable set


### PR DESCRIPTION
Hey, thanks for the project. I'm reading the docs these days (they're very well made, thanks for this), and I found just this small typo.