### PR TITLE
Correct handle exceptions in `legacy/broadcast`

### DIFF
--- a/src/websockets/legacy/protocol.py
+++ b/src/websockets/legacy/protocol.py
@@ -1637,5 +1637,5 @@ def broadcast(
                     exc_info=True,
                 )
 
-    if raise_exceptions:
+    if raise_exceptions and exceptions:
         raise ExceptionGroup("skipped broadcast", exceptions)


### PR DESCRIPTION
When enabling raise_exceptions in the broadcast method the code will always return an exception without this change