### PR TITLE
Rewrite sync Assembler to improve performance.

### DIFF
--- a/docs/project/changelog.rst
+++ b/docs/project/changelog.rst
@@ -70,10 +70,21 @@ Backwards-incompatible changes
     If you wrote an :class:`extension <extensions.Extension>` that relies on
     methods not provided by these new types, you may need to update your code.
 
+New features
+............
+
+* Added an option to receive text frames as :class:`bytes`, without decoding,
+  in the :mod:`threading` implementation; also binary frames as :class:`str`.
+
+* Added an option to send :class:`bytes` as a text frame in the :mod:`asyncio`
+  and :mod:`threading` implementations, as well as :class:`str` a binary frame.
+
 Improvements
 ............
 
-* Sending or receiving large compressed frames is now faster.
+* The :mod:`threading` implementation receives messages faster.
+
+* Sending or receiving large compressed messages is now faster.
 
 .. _13.1:
 
@@ -197,6 +208,9 @@ New features
     upgrade process.
 
 * Validated compatibility with Python 3.12 and 3.13.
+
+* Added an option to receive text frames as :class:`bytes`, without decoding,
+  in the :mod:`asyncio` implementation; also binary frames as :class:`str`.
 
 * Added :doc:`environment variables <../reference/variables>` to configure debug
   logs, the ``Server`` and ``User-Agent`` headers, as well as security limits.

--- a/src/websockets/asyncio/client.py
+++ b/src/websockets/asyncio/client.py
@@ -45,7 +45,7 @@ class ClientConnection(Connection):
     closed with any other code.
 
     The ``ping_interval``, ``ping_timeout``, ``close_timeout``, ``max_queue``,
-    and ``write_limit`` arguments the same meaning as in :func:`connect`.
+    and ``write_limit`` arguments have the same meaning as in :func:`connect`.
 
     Args:
         protocol: Sans-I/O connection.

--- a/src/websockets/asyncio/server.py
+++ b/src/websockets/asyncio/server.py
@@ -55,7 +55,7 @@ class ServerConnection(Connection):
     closed with any other code.
 
     The ``ping_interval``, ``ping_timeout``, ``close_timeout``, ``max_queue``,
-    and ``write_limit`` arguments the same meaning as in :func:`serve`.
+    and ``write_limit`` arguments have the same meaning as in :func:`serve`.
 
     Args:
         protocol: Sans-I/O connection.

--- a/src/websockets/sync/client.py
+++ b/src/websockets/sync/client.py
@@ -40,10 +40,12 @@ class ClientConnection(Connection):
     :exc:`~websockets.exceptions.ConnectionClosedError` when the connection is
     closed with any other code.
 
+    The ``close_timeout`` and ``max_queue`` arguments have the same meaning as
+    in :func:`connect`.
+
     Args:
         socket: Socket connected to a WebSocket server.
         protocol: Sans-I/O connection.
-        close_timeout: Timeout for closing the connection in seconds.
 
     """
 
@@ -53,6 +55,7 @@ class ClientConnection(Connection):
         protocol: ClientProtocol,
         *,
         close_timeout: float | None = 10,
+        max_queue: int | tuple[int, int | None] = 16,
     ) -> None:
         self.protocol: ClientProtocol
         self.response_rcvd = threading.Event()
@@ -60,6 +63,7 @@ class ClientConnection(Connection):
             socket,
             protocol,
             close_timeout=close_timeout,
+            max_queue=max_queue,
         )
 
     def handshake(
@@ -135,6 +139,7 @@ def connect(
     close_timeout: float | None = 10,
     # Limits
     max_size: int | None = 2**20,
+    max_queue: int | tuple[int, int | None] = 16,
     # Logging
     logger: LoggerLike | None = None,
     # Escape hatch for advanced customization
@@ -183,6 +188,10 @@ def connect(
             :obj:`None` disables the timeout.
         max_size: Maximum size of incoming messages in bytes.
             :obj:`None` disables the limit.
+        max_queue: High-water mark of the buffer where frames are received.
+            It defaults to 16 frames. The low-water mark defaults to ``max_queue
+            // 4``. You may pass a ``(high, low)`` tuple to set the high-water
+            and low-water marks.
         logger: Logger for this client.
             It defaults to ``logging.getLogger("websockets.client")``.
             See the :doc:`logging guide <../../topics/logging>` for details.
@@ -287,6 +296,7 @@ def connect(
             sock,
             protocol,
             close_timeout=close_timeout,
+            max_queue=max_queue,
         )
     except Exception:
         if sock is not None:

--- a/tests/asyncio/test_connection.py
+++ b/tests/asyncio/test_connection.py
@@ -793,8 +793,8 @@ class ClientConnectionTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(exc.__cause__, (socket.timeout, TimeoutError))
 
     async def test_close_does_not_wait_for_recv(self):
-        # The asyncio implementation has a buffer for incoming messages. Closing
-        # the connection discards buffered messages. This is allowed by the RFC:
+        # Closing the connection discards messages buffered in the assembler.
+        # This is allowed by the RFC:
         # > However, there is no guarantee that the endpoint that has already
         # > sent a Close frame will continue to process data.
         await self.remote_connection.send("😀")
@@ -1075,7 +1075,10 @@ class ClientConnectionTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_max_queue_tuple(self):
         """max_queue parameter configures high-water mark of frames buffer."""
-        connection = Connection(Protocol(self.LOCAL), max_queue=(4, 2))
+        connection = Connection(
+            Protocol(self.LOCAL),
+            max_queue=(4, 2),
+        )
         transport = Mock()
         connection.connection_made(transport)
         self.assertEqual(connection.recv_messages.high, 4)
@@ -1083,14 +1086,20 @@ class ClientConnectionTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_write_limit(self):
         """write_limit parameter configures high-water mark of write buffer."""
-        connection = Connection(Protocol(self.LOCAL), write_limit=4096)
+        connection = Connection(
+            Protocol(self.LOCAL),
+            write_limit=4096,
+        )
         transport = Mock()
         connection.connection_made(transport)
         transport.set_write_buffer_limits.assert_called_once_with(4096, None)
 
     async def test_write_limits(self):
         """write_limit parameter configures high and low-water marks of write buffer."""
-        connection = Connection(Protocol(self.LOCAL), write_limit=(4096, 2048))
+        connection = Connection(
+            Protocol(self.LOCAL),
+            write_limit=(4096, 2048),
+        )
         transport = Mock()
         connection.connection_made(transport)
         transport.set_write_buffer_limits.assert_called_once_with(4096, 2048)

--- a/tests/asyncio/test_messages.py
+++ b/tests/asyncio/test_messages.py
@@ -350,7 +350,7 @@ class AssemblerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(fragments, ["café"])
 
     async def test_cancel_get_iter_after_first_frame(self):
-        """get cannot be canceled after reading the first frame."""
+        """get_iter cannot be canceled after reading the first frame."""
         self.assembler.put(Frame(OP_TEXT, b"ca", fin=False))
 
         getter_task = asyncio.create_task(alist(self.assembler.get_iter()))
@@ -429,7 +429,7 @@ class AssemblerTests(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(0)
         with self.assertRaises(ConcurrencyError):
             await self.assembler.get()
-        self.assembler.close()  # let task terminate
+        self.assembler.put(Frame(OP_TEXT, b""))  # let task terminate
 
     async def test_get_fails_when_get_iter_is_running(self):
         """get cannot be called concurrently with get_iter."""
@@ -437,7 +437,7 @@ class AssemblerTests(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(0)
         with self.assertRaises(ConcurrencyError):
             await self.assembler.get()
-        self.assembler.close()  # let task terminate
+        self.assembler.put(Frame(OP_TEXT, b""))  # let task terminate
 
     async def test_get_iter_fails_when_get_is_running(self):
         """get_iter cannot be called concurrently with get."""
@@ -445,7 +445,7 @@ class AssemblerTests(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(0)
         with self.assertRaises(ConcurrencyError):
             await alist(self.assembler.get_iter())
-        self.assembler.close()  # let task terminate
+        self.assembler.put(Frame(OP_TEXT, b""))  # let task terminate
 
     async def test_get_iter_fails_when_get_iter_is_running(self):
         """get_iter cannot be called concurrently."""
@@ -453,7 +453,7 @@ class AssemblerTests(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(0)
         with self.assertRaises(ConcurrencyError):
             await alist(self.assembler.get_iter())
-        self.assembler.close()  # let task terminate
+        self.assembler.put(Frame(OP_TEXT, b""))  # let task terminate
 
     # Test setting limits
 
@@ -463,7 +463,7 @@ class AssemblerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(assembler.high, 10)
 
     async def test_set_high_and_low_water_mark(self):
-        """high sets the high-water mark."""
+        """high sets the high-water mark and low-water mark."""
         assembler = Assembler(high=10, low=5)
         self.assertEqual(assembler.high, 10)
         self.assertEqual(assembler.low, 5)


### PR DESCRIPTION
Previously, a latch was used to synchronize the user thread reading messages and the background thread reading from the network. This required two thread switches per message.

Now, the background thread writes messages to queue, from which the user thread reads. This allows passing several frames at each thread switch, reducing the overhead.

With this server code::

    async def test(websocket):
        for i in range(int(await websocket.recv())):
            await websocket.send(f"{{\"iteration\": {i}}}")

and this client code::

    with connect("ws://localhost:8765", compression=None) as websocket:
        websocket.send("1_000_000")
        for message in websocket:
            pass

an unscientific benchmark (running it on my laptop) shows a 2.5x speedup, going from 11 seconds to 4.4 seconds. Setting a very large recv_bufsize and max_size doesn't yield significant further improvement.

The new implementation mirrors the asyncio implementation and gains the option to prevent or force decoding of frames. Refs #1376.