### PR TITLE
Fix for Issue #1532

### DIFF
--- a/src/websockets/asyncio/connection.py
+++ b/src/websockets/asyncio/connection.py
@@ -216,7 +216,7 @@ class Connection(asyncio.Protocol):
             while True:
                 yield await self.recv()
         except ConnectionClosedOK:
-            return
+            raise ConnectionClosed
 
     async def recv(self, decode: bool | None = None) -> Data:
         """


### PR DESCRIPTION
This would allow People to be able to check the status of whether the connection is still running while iterating:
```
async for message in websocket:
    pass #something here
 ```
So then you could place a `try: ... except: ...` around this and exactly know that the client has disconnected and return from the handler saving resources of the server.

In addition I just want to say I really like working with this module and it's my first actively having something to contribute to a project. And even though it's only a very slight change I think it could be really helpful. So I just want to thank you for the opportunity for me to grow in this regard and possibly help out others as well