### PR TITLE
Implementationn of optional Solve for Suggested Change in Issue #1532

### DIFF
--- a/src/websockets/asyncio/server.py
+++ b/src/websockets/asyncio/server.py
@@ -73,6 +73,7 @@ class ServerConnection(Connection):
         close_timeout: float | None = 10,
         max_queue: int | tuple[int, int | None] = 16,
         write_limit: int | tuple[int, int | None] = 2**15,
+        raise_on_close: bool | None = None
     ) -> None:
         self.protocol: ServerProtocol
         super().__init__(
@@ -82,6 +83,7 @@ class ServerConnection(Connection):
             close_timeout=close_timeout,
             max_queue=max_queue,
             write_limit=write_limit,
+            raise_on_close=raise_on_close,
         )
         self.server = server
         self.request_rcvd: asyncio.Future[None] = self.loop.create_future()
@@ -739,7 +741,10 @@ class serve:
             kwargs.setdefault("ssl_handshake_timeout", open_timeout)
             if sys.version_info[:2] >= (3, 11):  # pragma: no branch
                 kwargs.setdefault("ssl_shutdown_timeout", close_timeout)
-
+        raise_on_close = None
+        if kwargs.get("raise_on_close") is not None and type(kwargs.get("raise_on_close")) == bool:
+            raise_on_close = kwargs.get("raise_on_close")
+        
         def factory() -> ServerConnection:
             """
             Create an asyncio protocol for managing a WebSocket connection.
@@ -783,6 +788,7 @@ class serve:
                 close_timeout=close_timeout,
                 max_queue=max_queue,
                 write_limit=write_limit,
+                raise_on_close=raise_on_close
             )
             return connection
 

--- a/src/websockets/asyncio/server.py
+++ b/src/websockets/asyncio/server.py
@@ -744,7 +744,7 @@ class serve:
         raise_on_close = None
         if kwargs.get("raise_on_close") is not None and type(kwargs.get("raise_on_close")) == bool:
             raise_on_close = kwargs.get("raise_on_close")
-        
+        kwargs.pop("raise_on_close")
         def factory() -> ServerConnection:
             """
             Create an asyncio protocol for managing a WebSocket connection.


### PR DESCRIPTION
This adds the optional keyword `raise_on_close` to the Constructor of the serve class allowing this parameter to propogate to the ServerConnection object, where it allows the following to raise an exception over the iteration:

```
async for message in server_connection:
    # handle Message
```
This enables the handeling of Connection Closure inside the Connection handeling function and can save the rescources of a handler continuing to run asynchronously without any Connection still being open. Especially for large scale Project this paramter could save a lot of rescources in RAM and of the CPU as the handlers could be easily freed from these resources upon the connection closing. This could be done in the following fashion:
```
try:
    while True:
        async for message in server_connection:
            # handle Message
except websockets.exception.ConnectionClosed:
    server_connection.close()
    return # return from handler 
```
This could simplify the handeling process all just by adding the feature: `serve([handler_function],[host],[port],[*args],[**kwargs],raise_on_close=True)` where `[]` are just placeholders here.

In this manner the async iteration would now behave similar to recv and send, if this behaviour is wanted, which gives a flexible usage for the async iteration and doesn't break systems designed for earlier versions. It does however break backwards compatibility because of the additional keyword parameter. In the future this might be resolved by adding a keyword garbage at the end in the Constructor to allow future non-breaking changes more easily.