### PR TITLE
Add missing import

### DIFF
--- a/docs/intro/tutorial1.rst
+++ b/docs/intro/tutorial1.rst
@@ -271,6 +271,8 @@ spot real errors when you add functionality to the server. Catch it in the
 
 .. code-block:: python
 
+    import websockets
+
     async def handler(websocket):
         while True:
             try:


### PR DESCRIPTION
When handling the ConnectionClosedOK exception the tutorial didn't mention the need to import websockets or just the exception