### PR TITLE
fix 403 forbidden when dial with CDN edge IP with Custom SNI

### DIFF
--- a/src/websockets/legacy/client.py
+++ b/src/websockets/legacy/client.py
@@ -278,8 +278,12 @@ class WebSocketClientProtocol(WebSocketCommonProtocol):
 
         """
         request_headers = Headers()
-
-        request_headers["Host"] = build_host(wsuri.host, wsuri.port, wsuri.secure)
+        # fix 403 forbidden when dial with CDN IP with Custom SNI
+        if extra_headers["Host"]:
+            request_headers["Host"] = extra_headers["Host"] # key point
+        else:
+            request_headers["Host"] = build_host(wsuri.host, wsuri.port, wsuri.secure)
+        # request_headers["Host"] = build_host(wsuri.host, wsuri.port, wsuri.secure)
 
         if wsuri.user_info:
             request_headers["Authorization"] = build_authorization_basic(


### PR DESCRIPTION
When dial with CDN edge IP with Custom SNI, such as url: wss://${cdn_edgeIP}:443/path, CDN will report 403 forbidden error

![image](https://github.com/user-attachments/assets/5ac3356c-ad75-429f-aae1-e00abdd1d8d6)

That is because CDN will verify both TLS SNI name and Host in request header , but  your below code will take IP as Host in request header when dial with CDN edge IP
```
build_host(wsuri.host, wsuri.port, wsuri.secure)
```
Hence we need to correct this bug.
The test code as below: 

```
import ssl
from websockets.client import connect
import asyncio
async def WssHandshake():
  
    server_host = '104.16.177.217' 
    server_port = 443  
    sni_hostname = 'testwebsocket.icanfly668.top'  

    
    ssl_context = ssl.create_default_context()


    headers = {
        'Host': sni_hostname,
        "User-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"
    }

  
    uri = f"wss://{server_host}:{server_port}/ws"
    async with connect(uri=uri, ssl=ssl_context,server_hostname=sni_hostname, 
        extra_headers=headers, subprotocols=["chat"]) as websocket:
        await websocket.send("Hello, WebSocket with SNI!")
        response = await websocket.recv()
        print(response)


asyncio.run(WssHandshake())
```
If take your old websockets version, it will report 403 forbbiden error. But take this PR code ,the error will be elimated