### PR TITLE
Resolve "Default `max_queue` blocks websocket cancellation with high traffic"

### DIFF
--- a/repro.py
+++ b/repro.py
@@ -1,0 +1,84 @@
+import asyncio
+import logging
+import json
+from websockets.asyncio.client import connect
+
+# import debugpy
+
+# # Allow VS Code to attach
+# debugpy.listen(("0.0.0.0", 5678))  # Use the port you've specified
+# print("Waiting for debugger to attach...")
+# debugpy.wait_for_client()
+
+logging.getLogger(__name__)
+logging.basicConfig(
+    format="%(asctime)s %(module)s:%(lineno)d %(levelname)8s | %(message)s",
+    datefmt="%Y/%m/%d %H:%M:%S",
+    level=logging.DEBUG,
+)
+
+class MyClient:
+
+    def __init__(self):
+        self.keep_alive = True
+
+    async def run(self):
+
+        async with connect(
+            f"wss://ws.kraken.com/v2",
+            ping_interval=30,
+            # max_queue=None,  # having this enabled doesn't cause problems
+        ) as socket:
+            await socket.send(
+                json.dumps(
+                    {
+                        "method": "subscribe",
+                        "params": {
+                            "channel": "book",
+                            "symbol": [
+                                "BTC/USD",
+                                "DOT/USD",
+                                "ETH/USD",
+                                "MATIC/USD",
+                                "BTC/EUR",
+                                "DOT/EUR",
+                                "ETH/EUR",
+                                "XLM/USD",
+                                "XLM/EUR",
+                            ],
+                            "depth": 100
+                        },
+                    }
+                )
+            )
+
+            while self.keep_alive:
+                try:
+                    _message = await asyncio.wait_for(socket.recv(), timeout=10)
+                except TimeoutError:
+                    pass
+                except asyncio.CancelledError:
+                    self.keep_alive = False
+                else:
+                    try:
+                        message = json.loads(_message)
+                    except ValueError:
+                        pass
+
+    async def __aenter__(self):
+        self.task: asyncio.Task = asyncio.create_task(self.run())
+        return self
+
+    async def __aexit__(self, *args, **kwargs):
+        self.keep_alive = False
+        if hasattr(self, "task") and not self.task.done():
+            await self.task
+
+
+async def main():
+    async with MyClient():
+        await asyncio.sleep(3)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/websockets/asyncio/connection.py
+++ b/src/websockets/asyncio/connection.py
@@ -913,6 +913,9 @@ class Connection(asyncio.Protocol):
         if wait_for_close:
             try:
                 async with asyncio_timeout_at(self.close_deadline):
+                    self.recv_messages.cancelling = True
+                    if self.recv_messages.paused:
+                        self.recv_messages.resume()
                     await asyncio.shield(self.connection_lost_waiter)
             except TimeoutError:
                 # There's no risk to overwrite another error because

--- a/src/websockets/asyncio/connection.py
+++ b/src/websockets/asyncio/connection.py
@@ -913,9 +913,7 @@ class Connection(asyncio.Protocol):
         if wait_for_close:
             try:
                 async with asyncio_timeout_at(self.close_deadline):
-                    self.recv_messages.cancelling = True
-                    if self.recv_messages.paused:
-                        self.recv_messages.resume()
+                    self.recv_messages.prepare_close()
                     await asyncio.shield(self.connection_lost_waiter)
             except TimeoutError:
                 # There's no risk to overwrite another error because

--- a/src/websockets/asyncio/messages.py
+++ b/src/websockets/asyncio/messages.py
@@ -292,6 +292,7 @@ class Assembler:
 
         # Resuming the writer to avoid deadlocks
         if self.paused:
+            self.paused = False
             self.resume()
 
     def close(self) -> None:

--- a/src/websockets/sync/messages.py
+++ b/src/websockets/sync/messages.py
@@ -291,7 +291,7 @@ class Assembler:
         """
         End the stream of frames.
 
-        Callling :meth:`close` concurrently with :meth:`get`, :meth:`get_iter`,
+        Calling :meth:`close` concurrently with :meth:`get`, :meth:`get_iter`,
         or :meth:`put` is safe. They will raise :exc:`EOFError`.
 
         """


### PR DESCRIPTION
## Problem statement

If `max_queue` is not set to `None` and the connection closes while receiving a high volume of messages, it can trigger `websockets.asyncio.client.messages.py:Assembler.paused == True`. This results in `self.pause()` blocking termination, as frames are still pending processing. This issue arises only when the connection handles a significant influx of messages between the initiation of cancellation and its final acknowledgment.

## Solution proposal

In order to avoid this behavior, we introduce `Assembler.prepare_close()` to continue any paused processing while setting `Assembler.closing=True` allows skipping further calls of `Assembler.maybe_pause()`. 

```diff
  # src.websockets.asyncio.connection.py:915... (see MR diff)
  async with asyncio_timeout_at(self.close_deadline):
+     self.recv_messages.prepare_close()
      await asyncio.shield(self.connection_lost_waiter)
``` 


Tasks:

- [x] add proper MR description and reasoning behind the change
- [x] add/update documentation (not needed I guess)
- [x] test the change properly
- [ ] remove repro file (after first review)

Closes #1555 