### PR TITLE
Ignore malformed pongs

### DIFF
--- a/src/websockets/asyncio/connection.py
+++ b/src/websockets/asyncio/connection.py
@@ -749,9 +749,9 @@ class Connection(asyncio.Protocol):
         ping_ids = []
         for ping_id, (pong_waiter, ping_timestamp) in self.pong_waiters.items():
             ping_ids.append(ping_id)
-            latency = pong_timestamp - ping_timestamp
-            pong_waiter.set_result(latency)
             if ping_id == data:
+                latency = pong_timestamp - ping_timestamp
+                pong_waiter.set_result(latency)
                 self.latency = latency
                 break
         else:


### PR DESCRIPTION
Fixes #1566, by following pong approach of only acknowledging last pong received https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.3

Any unmatched pong waiters are deleted when the next matching ping/pong is received. 