### PR TITLE
Fix Connection.recv(timeout=0) in the sync implementation.

### DIFF
--- a/docs/project/changelog.rst
+++ b/docs/project/changelog.rst
@@ -35,6 +35,10 @@ notice.
 Bug fixes
 .........
 
+* Fixed ``connection.recv(timeout=0)`` in the :mod:`threading` implementation.
+  If a message is already received, it is returned. Previously,
+  :exc:`TimeoutError` was raised incorrectly.
+
 * Wrapped errors when reading the opening handshake request or response in
   :exc:`~exceptions.InvalidMessage` so that :func:`~asyncio.client.connect`
   raises :exc:`~exceptions.InvalidHandshake` or a subclass when the opening

--- a/tests/sync/test_messages.py
+++ b/tests/sync/test_messages.py
@@ -198,6 +198,12 @@ class AssemblerTests(ThreadTestCase):
         message = self.assembler.get()
         self.assertEqual(message, "café")
 
+    def test_get_if_received(self):
+        """get returns a text message if it's already received."""
+        self.assembler.put(Frame(OP_TEXT, b"caf\xc3\xa9"))
+        message = self.assembler.get(timeout=0)
+        self.assertEqual(message, "café")
+
     # Test get_iter
 
     def test_get_iter_text_message_already_received(self):


### PR DESCRIPTION
Fix #1552.