### PR TITLE
Add regex support in `ServerProtocol(origins=...)`

### DIFF
--- a/src/websockets/asyncio/server.py
+++ b/src/websockets/asyncio/server.py
@@ -4,6 +4,7 @@ import asyncio
 import hmac
 import http
 import logging
+import re
 import socket
 import sys
 from collections.abc import Awaitable, Generator, Iterable, Sequence
@@ -599,9 +600,10 @@ class serve:
             See :meth:`~asyncio.loop.create_server` for details.
         port: TCP port the server listens on.
             See :meth:`~asyncio.loop.create_server` for details.
-        origins: Acceptable values of the ``Origin`` header, for defending
-            against Cross-Site WebSocket Hijacking attacks. Include :obj:`None`
-            in the list if the lack of an origin is acceptable.
+        origins: Acceptable values of the ``Origin`` header, including regular
+            expressions, for defending against Cross-Site WebSocket Hijacking
+            attacks. Include :obj:`None` in the list if the lack of an origin
+            is acceptable.
         extensions: List of supported extensions, in order in which they
             should be negotiated and run.
         subprotocols: List of supported subprotocols, in order of decreasing
@@ -681,7 +683,7 @@ class serve:
         port: int | None = None,
         *,
         # WebSocket
-        origins: Sequence[Origin | None] | None = None,
+        origins: Sequence[Origin | re.Pattern[str] | None] | None = None,
         extensions: Sequence[ServerExtensionFactory] | None = None,
         subprotocols: Sequence[Subprotocol] | None = None,
         select_subprotocol: (

--- a/src/websockets/sync/server.py
+++ b/src/websockets/sync/server.py
@@ -4,6 +4,7 @@ import hmac
 import http
 import logging
 import os
+import re
 import selectors
 import socket
 import ssl as ssl_module
@@ -325,7 +326,7 @@ def serve(
     sock: socket.socket | None = None,
     ssl: ssl_module.SSLContext | None = None,
     # WebSocket
-    origins: Sequence[Origin | None] | None = None,
+    origins: Sequence[Origin | re.Pattern[str] | None] | None = None,
     extensions: Sequence[ServerExtensionFactory] | None = None,
     subprotocols: Sequence[Subprotocol] | None = None,
     select_subprotocol: (
@@ -399,9 +400,10 @@ def serve(
             You may call :func:`socket.create_server` to create a suitable TCP
             socket.
         ssl: Configuration for enabling TLS on the connection.
-        origins: Acceptable values of the ``Origin`` header, for defending
-            against Cross-Site WebSocket Hijacking attacks. Include :obj:`None`
-            in the list if the lack of an origin is acceptable.
+        origins: Acceptable values of the ``Origin`` header, including regular
+            expressions, for defending against Cross-Site WebSocket Hijacking
+            attacks. Include :obj:`None` in the list if the lack of an origin
+            is acceptable.
         extensions: List of supported extensions, in order in which they
             should be negotiated and run.
         subprotocols: List of supported subprotocols, in order of decreasing


### PR DESCRIPTION
Hello. In my project I tried to pass a regular expression to `origins`, but it didn't work.
I think this will not be superfluous for the project.
Idea taken from [https://github.com/corydolphin/flask-cors/blob/main/flask_cors/core.py](https://github.com/corydolphin/flask-cors/blob/main/flask_cors/core.py)