### PR TITLE
Fix incorrect asyncio import in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Here's an echo server with the ``asyncio`` API:
     #!/usr/bin/env python
 
     import asyncio
-    from websockets.server import serve
+    from websockets.asyncio.server import serve
 
     async def echo(websocket):
         async for message in websocket:


### PR DESCRIPTION
The primary README has an invalid import in the asyncio example.

Changes:
- `serve` is now correctly imported from `websockets.asyncio.server`