### PR TITLE
Define Entry Point in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ Documentation = "https://websockets.readthedocs.io/"
 Funding = "https://tidelift.com/subscription/pkg/pypi-websockets?utm_source=pypi-websockets&utm_medium=referral&utm_campaign=readme"
 Tracker = "https://github.com/python-websockets/websockets/issues"
 
+[project.scripts]
+websockets = "websockets.__main__:main"
+
 [tool.cibuildwheel]
 enable = ["pypy"]
 


### PR DESCRIPTION
Thank you for this amazing package! 
I find my self using the interactive client tool often, which is a great way to quickly test out my websocket server. 
Currently I would need to have activated an environment with websockets installed to be able to run the interactive client.
I would love the ability to run the client as a global tool, and think this workflow is now more mainstream with tools like uv and pipx. 

Defining an entry point in pyproject.toml will enable use of the interactive client with both uv tool/uvx and pipx. 

One issue though:
I tested it out locally and it works with uv. However it does not handle keyboard interrupts properly and does not close the connection gracefully. I can't seem to figure out where the issue is, since there is an exception handler for keyboard interrupts. Would love any input on what is wrong. 
This is not specific to the way the interactive client is run (happens with both uvx and python -m), but specific to my local version of websockets.