### PR TITLE
Gracefully closing the cli when KeyboardInterrupt signal is sent 

### DIFF
--- a/src/websockets/cli.py
+++ b/src/websockets/cli.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-from asyncio import CancelledError
 import os
 import sys
+from asyncio import CancelledError
 from typing import Generator
 
 from .asyncio.client import ClientConnection, connect

--- a/src/websockets/cli.py
+++ b/src/websockets/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from asyncio import CancelledError
 import os
 import sys
 from typing import Generator
@@ -123,7 +124,7 @@ async def interactive_client(uri: str) -> None:
             [incoming, outgoing],
             return_when=asyncio.FIRST_COMPLETED,
         )
-    except (KeyboardInterrupt, EOFError):  # ^C, ^D  # pragma: no cover
+    except CancelledError:  # ^C, ^D  # pragma: no cover
         pass
     finally:
         incoming.cancel()


### PR DESCRIPTION
While setting up entry point for the cli (#1598) we saw that the cli does not properly close the connection on KeyboardInterrupt. 

Doing a bit of research it seems that asyncio will catch KeyboardInterrupt outside of the task and then cancel the task. From python 3.11 asyncio will raise a CancelledError in the task instead. Catching this in our tasks enable the cli to gracefully exit with no error. In python 3.9 and 3.10 this will still properly close the websocket connection, but you will get a KeyboardInterrupt error (still outside our task, so catching this error inside the task does not change anything). 

Should we also silent the error in python 3.9 and python 3.10?