### PR TITLE
Sync Connection garbage collection closing

### DIFF
--- a/src/websockets/sync/connection.py
+++ b/src/websockets/sync/connection.py
@@ -226,6 +226,9 @@ class Connection:
         else:
             self.close(CloseCode.INTERNAL_ERROR)
 
+    def __del__(self) -> None:
+        self.close()
+
     def __iter__(self) -> Iterator[Data]:
         """
         Iterate on incoming messages.


### PR DESCRIPTION
Ensures the sync connection is closed when the object is garbage collected.

While in a perfect world, everyone would correctly use the context manager, I've found this is not the case. In a situation like this, it's possible for a memory leak to be caused by the connection never being closed. This ensures graceful closing when the Connection object is garbage collected.