### PR TITLE
Implement connection tracking and graceful shutdown (sync server)

### DIFF
--- a/tests/sync/test_server.py
+++ b/tests/sync/test_server.py
@@ -7,13 +7,13 @@ import threading
 import time
 import unittest
 
+from websockets import CloseCode
 from websockets.exceptions import (
     ConnectionClosedError,
     ConnectionClosedOK,
     InvalidStatus,
     NegotiationError,
 )
-from websockets import CloseCode, State
 from websockets.http11 import Request, Response
 from websockets.sync.client import connect, unix_connect
 from websockets.sync.server import *
@@ -352,7 +352,7 @@ class ServerTests(EvalShellMixin, unittest.TestCase):
         """Clients are added to Server._connections, and removed when disconnected."""
         with run_server() as server:
             connections: set[ServerConnection] = server._connections
-            with connect(get_uri(server)) as client:
+            with connect(get_uri(server)):
                 self.assertEqual(len(connections), 1)
             time.sleep(0.5)
             self.assertEqual(len(connections), 0)
@@ -382,7 +382,7 @@ class ServerTests(EvalShellMixin, unittest.TestCase):
         with run_server(create_connection=ServerConnectionWithBrokenClose) as server:
 
             def client():
-                with connect(get_uri(server)) as client:
+                with connect(get_uri(server)):
                     time.sleep(1)
 
             for i in range(CLIENTS_TO_LAUNCH):


### PR DESCRIPTION
Hi again, I implemented the connection tracking and graceful server shutdown procedure that I explained in [issue #1488](https://github.com/python-websockets/websockets/issues/1488#issuecomment-2778939350).

### Server shutdown behavior

In the current version, the sync server does not have a way of tracking active connections. After launching the handler into a separate thread, the Server instance forgets about that connection. When we want to interrupt the server process with an interrupt, this can cause the process to continue running due to remaining active connections.

I updated `src/websockets/sync/server.py` to add logic for better handling graceful shutdowns. I also added optional arguments `code` and `reason` that are passed to the clients with `ServerConnection.close(code, reason)` which allows additional information to be provided to the clients.

### Considerations

One of the things I considered when choosing how to update active connections is the existing API. I am not sure if there are users who instantiate Server() differently in their codebases, as opposed to the recommended `server = serve(socket, handle, ...)` approach. Therefore, I think there could be complaints about changing the signature of `conn_handler()`. So, I kept it unchanged. I did add an optional argument to the constructor of `Server` (as a keyword-only arg, so I think it won't be a problem either).

I added some tests in `tests/sync/test_server.py`, and tried to match the style of existing tests there.

Please let me know if anyone has suggestions on this.

*Update: fixed a typo "sync server does have" -> "sync server does **not** have"*