### PR TITLE
Add support for HTTP/1.0 proxies.

### DIFF
--- a/docs/project/changelog.rst
+++ b/docs/project/changelog.rst
@@ -32,6 +32,11 @@ notice.
 
 *In development*
 
+Improvements
+............
+
+* Added support for HTTP/1.0 proxies.
+
 15.0.1
 ------
 

--- a/src/websockets/asyncio/client.py
+++ b/src/websockets/asyncio/client.py
@@ -754,8 +754,7 @@ class HTTPProxyConnection(asyncio.Protocol):
             self.reader.read_line,
             self.reader.read_exact,
             self.reader.read_to_eof,
-            include_body=False,
-            allow_http10=True,
+            proxy=True,
         )
 
         loop = asyncio.get_running_loop()

--- a/src/websockets/asyncio/client.py
+++ b/src/websockets/asyncio/client.py
@@ -755,6 +755,7 @@ class HTTPProxyConnection(asyncio.Protocol):
             self.reader.read_exact,
             self.reader.read_to_eof,
             include_body=False,
+            allow_http10=True,
         )
 
         loop = asyncio.get_running_loop()

--- a/src/websockets/sync/client.py
+++ b/src/websockets/sync/client.py
@@ -498,8 +498,7 @@ def read_connect_response(sock: socket.socket, deadline: Deadline) -> Response:
         reader.read_line,
         reader.read_exact,
         reader.read_to_eof,
-        include_body=False,
-        allow_http10=True,
+        proxy=True,
     )
     try:
         while True:

--- a/src/websockets/sync/client.py
+++ b/src/websockets/sync/client.py
@@ -499,6 +499,7 @@ def read_connect_response(sock: socket.socket, deadline: Deadline) -> Response:
         reader.read_exact,
         reader.read_to_eof,
         include_body=False,
+        allow_http10=True,
     )
     try:
         while True:

--- a/tests/test_http11.py
+++ b/tests/test_http11.py
@@ -333,6 +333,23 @@ class ResponseTests(GeneratorTestCase):
         response = self.assertGeneratorReturns(self.parse(include_body=False))
         self.assertEqual(response.body, b"")
 
+    def test_parse_http10(self):
+        self.reader.feed_data(b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n")
+        response = self.assertGeneratorReturns(self.parse(allow_http10=True))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.reason_phrase, "OK")
+        self.assertEqual(response.body, b"")
+
+    def test_parse_http10_unsupported_protocol(self):
+        self.reader.feed_data(b"HTTP/1.2 400 Bad Request\r\n\r\n")
+        with self.assertRaises(ValueError) as raised:
+            next(self.parse(allow_http10=True))
+        self.assertEqual(
+            str(raised.exception),
+            "unsupported protocol; expected HTTP/1.1 or HTTP/1.0: "
+            "HTTP/1.2 400 Bad Request",
+        )
+
     def test_serialize(self):
         # Example from the protocol overview in RFC 6455
         response = Response(

--- a/tests/test_http11.py
+++ b/tests/test_http11.py
@@ -328,22 +328,22 @@ class ResponseTests(GeneratorTestCase):
         response = self.assertGeneratorReturns(self.parse())
         self.assertEqual(response.body, b"")
 
-    def test_parse_without_body(self):
+    def test_parse_proxy_response_does_not_read_body(self):
         self.reader.feed_data(b"HTTP/1.1 200 Connection Established\r\n\r\n")
-        response = self.assertGeneratorReturns(self.parse(include_body=False))
+        response = self.assertGeneratorReturns(self.parse(proxy=True))
         self.assertEqual(response.body, b"")
 
-    def test_parse_http10(self):
+    def test_parse_proxy_http10(self):
         self.reader.feed_data(b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n")
-        response = self.assertGeneratorReturns(self.parse(allow_http10=True))
+        response = self.assertGeneratorReturns(self.parse(proxy=True))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.reason_phrase, "OK")
         self.assertEqual(response.body, b"")
 
-    def test_parse_http10_unsupported_protocol(self):
+    def test_parse_proxy_unsupported_protocol(self):
         self.reader.feed_data(b"HTTP/1.2 400 Bad Request\r\n\r\n")
         with self.assertRaises(ValueError) as raised:
-            next(self.parse(allow_http10=True))
+            next(self.parse(proxy=True))
         self.assertEqual(
             str(raised.exception),
             "unsupported protocol; expected HTTP/1.1 or HTTP/1.0: "


### PR DESCRIPTION
It is legal to answer an HTTP/1.1 request with an HTTP/1.0 response.

Fix #1609.