### PR TITLE
More explicit error message when redirected to a non websocket uri

### DIFF
--- a/src/websockets/asyncio/client.py
+++ b/src/websockets/asyncio/client.py
@@ -18,6 +18,7 @@ from ..exceptions import (
     InvalidProxyMessage,
     InvalidProxyStatus,
     InvalidStatus,
+    InvalidURI,
     ProxyError,
     SecurityError,
 )
@@ -493,7 +494,10 @@ class connect:
 
         old_ws_uri = parse_uri(self.uri)
         new_uri = urllib.parse.urljoin(self.uri, exc.response.headers["Location"])
-        new_ws_uri = parse_uri(new_uri)
+        try:
+            new_ws_uri = parse_uri(new_uri)
+        except InvalidURI as uri_exception:
+            raise InvalidURI("Redirection URI is invalid", uri_exception)
 
         # If connect() received a socket, it is closed and cannot be reused.
         if self.connection_kwargs.get("sock") is not None:


### PR DESCRIPTION
When using the asyncio client, the error message and exception raised is the same if the user provides an incorrect uri or if the server respondes with a 302 found with a location header pointing to an incorrect uri.

This is quite confusing as it took me some time and debugging of the websocket library to figure out that the problem wasn't directly in my code but rather in the response of the server.

The current behavior isn't a bug as the uri was indeed a webpage and not a websocket so an exception in this scenario is normal. However a more explicit error message would help users understand the exact issue better.

As a result I'm suggesting changes to catch the InvalidUri exception in this scenario and modify the error message to make it more explicit. I also added a test to reflect theses changes.