### PR TITLE
Fix `from websockets.(asyncio|sync).router import *` without werkzeug

### DIFF
--- a/src/websockets/asyncio/router.py
+++ b/src/websockets/asyncio/router.py
@@ -35,6 +35,10 @@ except ImportError:
     ) -> Awaitable[Server]:
         raise ImportError("unix_route() requires werkzeug")
 
+    class Router:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise ImportError("Router() requires werkzeug")
+
 else:
 
     class Router:

--- a/src/websockets/sync/router.py
+++ b/src/websockets/sync/router.py
@@ -35,6 +35,10 @@ except ImportError:
     ) -> Server:
         raise ImportError("unix_route() requires werkzeug")
 
+    class Router:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise ImportError("Router() requires werkzeug")
+
 else:
 
     class Router:

--- a/tests/asyncio/test_router.py
+++ b/tests/asyncio/test_router.py
@@ -186,6 +186,7 @@ class RouterTests(EvalShellMixin, unittest.IsolatedAsyncioTestCase):
 
 
 @unittest.skipUnless(hasattr(socket, "AF_UNIX"), "this test requires Unix sockets")
+@unittest.skipUnless("werkzeug" in sys.modules, "werkzeug not installed")
 class UnixRouterTests(EvalShellMixin, unittest.IsolatedAsyncioTestCase):
     async def test_router_supports_unix_sockets(self):
         """Router supports Unix sockets."""

--- a/tests/sync/test_router.py
+++ b/tests/sync/test_router.py
@@ -162,6 +162,7 @@ class RouterTests(EvalShellMixin, unittest.TestCase):
 
 
 @unittest.skipUnless(hasattr(socket, "AF_UNIX"), "this test requires Unix sockets")
+@unittest.skipUnless("werkzeug" in sys.modules, "werkzeug not installed")
 class UnixRouterTests(EvalShellMixin, unittest.IsolatedAsyncioTestCase):
     def test_router_supports_unix_sockets(self):
         """Router supports Unix sockets."""


### PR DESCRIPTION
This is a followup for 3128f5619de15991ec2af93d68c9c6626c6a5ae0

Also, skip test_router_supports_unix_sockets without werkzeug.