### PR TITLE
Fix Frame.__str__() crashing on OP_TEXT frames with partial UTF-8 data

### DIFF
--- a/src/websockets/frames.py
+++ b/src/websockets/frames.py
@@ -159,7 +159,13 @@ class Frame:
         if self.opcode is OP_TEXT:
             # Decoding only the beginning and the end is needlessly hard.
             # Decode the entire payload then elide later if necessary.
-            data = repr(bytes(self.data).decode())
+            # If the frame contains an incomplete UTF-8 sequence (e.g., a
+            # text message fragmented at a byte boundary that isn't a
+            # character boundary), fall back to a hex representation.
+            try:
+                data = repr(bytes(self.data).decode())
+            except UnicodeDecodeError:
+                data = " ".join(f"{byte:02x}" for byte in self.data)
         elif self.opcode is OP_BINARY:
             # We'll show at most the first 16 bytes and the last 8 bytes.
             # Encode just what we need, plus two dummy bytes to elide later.


### PR DESCRIPTION
## Summary

When `Frame.__str__()` is called on an OP_TEXT frame whose payload contains an incomplete UTF-8 byte sequence, it raises `UnicodeDecodeError`. This can occur when a text message is fragmented at a byte boundary that falls in the middle of a multi-byte character (e.g., Japanese/Chinese/emoji text).

The crash is most visible when DEBUG logging is enabled: the library logs sent/received frames via `logger.debug(\%s\, frame)`, and the unhandled exception can tear down the WebSocket connection with code 1007 (INVALID_DATA) — even though the message data itself is perfectly valid per RFC 6455 (fragmentation is allowed at any byte boundary).

## Fix

Wrap the `decode()` call in the OP_TEXT branch of `Frame.__str__()` in a try/except. On `UnicodeDecodeError`, fall back to a hex representation — the same format already used for binary frames and as a fallback for continuation/ping/pong frames.

## Changes

- **File:** `src/websockets/frames.py`
- **Lines changed:** +7, −1 (net +6)

## Testing

- Verified normal UTF-8 text frames still render correctly (no regression)
- Verified truncated multi-byte sequences fall back to hex without crashing
- All 118 existing tests in test_frames.py, test_exceptions.py, test_utils.py, test_datastructures.py pass

Fixes #1695