### PR TITLE
Stop reading when the opening handshake fails.

### DIFF
--- a/docs/project/changelog.rst
+++ b/docs/project/changelog.rst
@@ -117,6 +117,9 @@ Bug fixes
 
 * Restored compatibility of the ``websockets`` CLI with Windows.
 
+* Fixed a race condition that could delay closing connections in the
+  :mod:`threading` implementation.
+
 .. _16.1.1:
 
 16.1.1

--- a/src/websockets/sync/connection.py
+++ b/src/websockets/sync/connection.py
@@ -22,7 +22,7 @@ from ..exceptions import (
 )
 from ..frames import DATA_OPCODES, CloseCode, Frame, Opcode
 from ..http11 import Request, Response
-from ..protocol import CLOSED, OPEN, Event, Protocol, State
+from ..protocol import CLOSED, CONNECTING, OPEN, Event, Protocol, State
 from ..typing import BytesLike, Data, DataLike, LoggerLike, Subprotocol
 from .messages import Assembler
 from .utils import Deadline
@@ -870,6 +870,14 @@ class Connection:
                         if self.close_deadline is None:
                             self.close_deadline = Deadline(self.close_timeout)
 
+                    # If the opening handshake failed, the connection never
+                    # reached the OPEN state and there's no closing handshake
+                    # to wait for. Remember this so we can stop reading below.
+                    handshake_failed = (
+                        self.protocol.state is CONNECTING
+                        and self.protocol.close_expected()
+                    )
+
                 # Unlock conn_mutex before processing events. Else, the
                 # application can't send messages in response to events.
 
@@ -880,6 +888,17 @@ class Connection:
                 for event in events:
                     # This isn't expected to raise an exception.
                     self.process_event(event)
+
+                # When the opening handshake fails, the connection is unusable
+                # and close_socket() runs as soon as the handshake failure
+                # propagates. Stop reading instead of waiting for the peer to
+                # close the TCP connection, because closing a socket in one
+                # thread doesn't always interrupt recv() in another thread --
+                # e.g. on macOS, when the protocol already half-closed the
+                # socket, shutdown() fails with ENOTCONN and close() doesn't
+                # interrupt recv().
+                if handshake_failed:
+                    break
 
             # Breaking out of the while True: ... loop means that we believe
             # that the socket doesn't work anymore.

--- a/tests/sync/test_client.py
+++ b/tests/sync/test_client.py
@@ -1,3 +1,4 @@
+import errno
 import http
 import logging
 import os
@@ -189,6 +190,79 @@ class ClientTests(unittest.TestCase):
                 str(raised.exception.__cause__),
                 "connection closed while reading HTTP status line",
             )
+
+    def test_connection_closed_promptly_after_invalid_status_response(self):
+        """Client closes the connection promptly when the handshake fails."""
+
+        class HalfClosingSocket(socket.socket):
+            """
+            Reproduces the shutdown()/close() semantics observed on macOS:
+            once the protocol half-closes the socket for writing, a further
+            shutdown() raises ENOTCONN instead of succeeding, and close()
+            doesn't interrupt a recv() call already blocked in another
+            thread.
+
+            """
+
+            def __init__(self, plain):
+                super().__init__(fileno=plain.detach())
+                self.half_closed = False
+
+            def shutdown(self, how):
+                if how == socket.SHUT_WR and not self.half_closed:
+                    self.half_closed = True
+                    super().shutdown(how)
+                else:
+                    raise OSError(errno.ENOTCONN, "Socket is not connected")
+
+            def close(self):
+                pass  # doesn't interrupt a recv() blocked in another thread
+
+            def really_close(self):
+                super().close()
+
+        response = (
+            b"HTTP/1.1 302 Found\r\n"
+            b"Location: http://localhost/\r\n"
+            b"Content-Length: 0\r\n"
+            b"\r\n"
+        )
+        keep_open = threading.Event()
+
+        def keep_connection_open():
+            conn, _ = server.accept()
+            with conn:
+                request = b""
+                while b"\r\n\r\n" not in request:
+                    data = conn.recv(4096)
+                    if data == b"":  # pragma: no cover
+                        return
+                    request += data
+                conn.sendall(response)
+                # Keep the TCP connection open past the handshake failure.
+                keep_open.wait()
+
+        with socket.create_server(("localhost", 0)) as server:
+            host, port = server.getsockname()
+
+            thread = threading.Thread(target=keep_connection_open)
+            thread.start()
+            self.addCleanup(thread.join)
+            self.addCleanup(keep_open.set)
+
+            plain = socket.create_connection((host, port))
+            sock = HalfClosingSocket(plain)
+            self.addCleanup(sock.really_close)
+
+            t0 = time.time()
+            with self.assertRaises(InvalidStatus):
+                with connect(f"ws://{host}:{port}/", sock=sock, close_timeout=20 * MS):
+                    self.fail("did not raise")
+            t1 = time.time()
+
+        # The client doesn't wait anywhere close to close_timeout because it
+        # doesn't wait for the peer to close the connection.
+        self.assertLess(t1 - t0, 10 * MS)
 
     def test_http_response(self):
         """Client reads HTTP response."""

--- a/tests/sync/test_connection.py
+++ b/tests/sync/test_connection.py
@@ -661,6 +661,33 @@ class ClientConnectionTests(ThreadTestCase):
         )
         self.assertIsNone(exc.__cause__)
 
+    # Test closing the connection when the opening handshake fails.
+
+    def test_stops_reading_when_the_opening_handshake_fails(self):
+        """recv_events stops reading when the opening handshake fails."""
+        socket_, remote_socket = socket.socketpair()
+        self.addCleanup(remote_socket.close)
+        # Simulate the state of the protocol after the opening handshake
+        # failed: EOF was sent, incoming data is discarded, and the state
+        # is still CONNECTING. See ClientProtocol.parse and
+        # ServerProtocol.parse.
+        protocol = Protocol(self.LOCAL, state=State.CONNECTING)
+        protocol.send_eof()
+        protocol.parser = protocol.discard()
+        next(protocol.parser)  # start coroutine
+        connection = Connection(socket_, protocol, close_timeout=20 * MS)
+        self.addCleanup(connection.close_socket)
+
+        t0 = time.time()
+        remote_socket.sendall(b"remaining data to discard")
+        connection.recv_events_thread.join(1)
+        t1 = time.time()
+
+        # The connection closes promptly instead of waiting for the peer to
+        # close the TCP connection.
+        self.assertFalse(connection.recv_events_thread.is_alive())
+        self.assertLess(t1 - t0, 10 * MS)
+
     # Test ping.
 
     @patch("random.getrandbits")


### PR DESCRIPTION
Fix #1596.

I could reproduce the delay on macOS (Python 3.13) when the server rejects the handshake and keeps the TCP connection open, for both `ws://` and `wss://`, at a 30-75% rate per attempt. The mechanism turned out a little different from the issue description.

After parsing the non-101 response, the protocol sends EOF, so `send_data()` half-closes the socket with `shutdown(SHUT_WR)` and `recv_events()` blocks in a `recv()` bounded by `close_deadline`, waiting for the server to close the connection. When `close_socket()` then runs in the thread that called `connect()`, its `shutdown(SHUT_RDWR)` is a second `shutdown()` on a half-closed socket. On macOS that raises `ENOTCONN`, which the existing `except OSError: pass` swallows, and `close()` doesn't reliably interrupt a `recv()` that's already blocked. `recv_events()` rides out `close_timeout`, or blocks forever with `close_timeout=None`. On Linux the second `shutdown()` succeeds, which is why this doesn't reproduce there.

About the issue description: the explanation based on signals didn't hold up when I tested it. Signals are indeed delivered only to the main thread, which is why Ctrl-C in #1592 interrupted `join()` rather than `recv()`, but waking a blocked `recv()` with `shutdown()` and `close()` doesn't involve signals. As long as the socket isn't already half-closed, it works reliably from any thread; I measured 20/20 prompt wakeups with `recv()` blocked in a background thread and 10/10 with the roles reversed, `recv()` in the main thread and the closing calls in a background thread. The ordering described in the issue is real: `recv_events()` has to be blocked in `recv()` before `close_socket()` runs. What makes the wakeup fail is the prior half-close, not which thread `recv()` runs on.

I couldn't find any combination of `shutdown()`/`close()` calls that interrupts the blocked `recv()` reliably on macOS, so the fix removes the wait instead: when the opening handshake failed, the connection is unusable and `close_socket()` runs as soon as the failure propagates, so there's no point waiting for the peer to close the connection. `recv_events()` stops reading and tears down the socket in its own thread, without depending on cross-thread wakeup. With this change I measured 0 delayed teardowns in 80 attempts, versus 30 in 40 before.

The other scenario, where the server never responds and `open_timeout` fires, didn't hang in my tests: there's no prior half-close, so the first `shutdown()` succeeds and interrupts the initial `recv()` reliably. It's unchanged.

The client test simulates the macOS `shutdown()`/`close()` semantics at the socket level, so it fails without the fix on any OS, including Linux CI. The connection-level test exercises the new branch for both sides, which also keeps `maxi_cov` at 100%.
