### PR TITLE
Reject permessage-deflate continuation frames with RSV1 set

### DIFF
--- a/docs/project/changelog.rst
+++ b/docs/project/changelog.rst
@@ -48,6 +48,9 @@ Bug fixes
 * Prevented ``Frame.__str__`` from crashing when a text frame is fragmented in
   the middle of a UTF-8 sequence.
 
+* Rejected incoming ``permessage-deflate`` continuation frames with the RSV1
+  bit set, as required by :rfc:`7692`.
+
 .. _16.0:
 
 16.0

--- a/src/websockets/extensions/permessage_deflate.py
+++ b/src/websockets/extensions/permessage_deflate.py
@@ -104,9 +104,12 @@ class PerMessageDeflate(Extension):
             return frame
 
         # Handle continuation data frames:
+        # - reject the rsv1 flag, which is only valid on the first frame
         # - skip if the message isn't encoded
         # - reset "decode continuation data" flag if it's a final frame
         if frame.opcode is frames.OP_CONT:
+            if frame.rsv1:
+                raise ProtocolError("reserved bits must be 0")
             if not self.decode_cont_data:
                 return frame
             if frame.fin:

--- a/tests/extensions/test_permessage_deflate.py
+++ b/tests/extensions/test_permessage_deflate.py
@@ -213,6 +213,31 @@ class PerMessageDeflateTests(unittest.TestCase, PerMessageDeflateTestsMixin):
         self.assertEqual(dec_frame1, frame1)
         self.assertEqual(dec_frame2, frame2)
 
+    def test_decode_rsv1_on_compressed_continuation_frame(self):
+        # RSV1 marks the first frame of a compressed message; it must not be
+        # set on continuation frames (RFC 7692, section 6.2).
+        frame1 = Frame(OP_TEXT, "café".encode(), fin=False)
+        frame2 = Frame(OP_CONT, " & ".encode(), fin=False)
+
+        enc_frame1 = self.extension.encode(frame1)
+        enc_frame2 = self.extension.encode(frame2)
+
+        self.extension.decode(enc_frame1)
+
+        with self.assertRaises(ProtocolError):
+            self.extension.decode(dataclasses.replace(enc_frame2, rsv1=True))
+
+    def test_decode_rsv1_on_uncompressed_continuation_frame(self):
+        # An uncompressed message has no RSV1 on any of its frames, including
+        # continuation frames (RFC 7692, section 6.2).
+        frame1 = Frame(OP_TEXT, "café".encode(), fin=False)
+        frame2 = Frame(OP_CONT, " & ".encode(), fin=False)
+
+        self.extension.decode(frame1)
+
+        with self.assertRaises(ProtocolError):
+            self.extension.decode(dataclasses.replace(frame2, rsv1=True))
+
     def test_context_takeover(self):
         frame = Frame(OP_TEXT, "café".encode())
 


### PR DESCRIPTION
Fixes #1720.

## Root cause

Per [RFC 7692, section 6.2](https://datatracker.ietf.org/doc/html/rfc7692#section-6.2), the RSV1 bit marks the **first** frame of a compressed message. It must not be set on continuation frames; a continuation frame with RSV1 set is a protocol error.

`PerMessageDeflate.decode()` handled the RSV1 bit only in the first-frame branch. The continuation branch (`frame.opcode is frames.OP_CONT`) never inspected `frame.rsv1`, and the method always returns the frame with `rsv1` unset:

```python
return frames.Frame(
    frame.opcode,
    data,
    frame.fin,
    False,  # rsv1 always cleared
    frame.rsv2,
    frame.rsv3,
)
```

So an illegal RSV1 bit on a **compressed** continuation frame was silently swallowed before `Frame.check()` (which raises `ProtocolError("reserved bits must be 0")`) could ever see it. As @aaugustin noted in the issue, the symmetric send side was already fixed in #866; the receive side was missed.

## Before

```python
extension = PerMessageDeflate(False, False, 15, 15)
compressed = compressed_message(b'{"cmd":"admin"}')
split = len(compressed) // 2

extension.decode(Frame(OP_TEXT, compressed[:split], fin=False, rsv1=True))   # legal first frame
extension.decode(Frame(OP_CONT, compressed[split:], fin=True, rsv1=True))    # illegal: accepted and decoded
```

| Frame | Before this PR | After this PR |
|-------|---------------|---------------|
| `OP_CONT`, `rsv1=1`, compressed | accepted, decompressed | `ProtocolError: reserved bits must be 0` |
| `OP_CONT`, `rsv1=1`, uncompressed | passed through with `rsv1=1` (caught later by `Frame.check()`) | `ProtocolError: reserved bits must be 0` (rejected at the extension layer, consistently) |

## Fix

Reject the RSV1 bit at the top of the continuation branch, reusing the existing `"reserved bits must be 0"` protocol error used by `Frame.check()`. Both compressed and uncompressed continuation frames are now rejected consistently at the extension layer.

```diff
         # Handle continuation data frames:
+        # - reject the rsv1 flag, which is only valid on the first frame
         # - skip if the message isn't encoded
         # - reset "decode continuation data" flag if it's a final frame
         if frame.opcode is frames.OP_CONT:
+            if frame.rsv1:
+                raise ProtocolError("reserved bits must be 0")
             if not self.decode_cont_data:
                 return frame
             if frame.fin:
                 self.decode_cont_data = False
```

## Tests

Two regression tests added to `tests/extensions/test_permessage_deflate.py` (compressed and uncompressed continuation frames). Proven to guard the bug by stashing only the source change:

- **Without the fix:** both tests `FAIL` with `AssertionError: ProtocolError not raised`.
- **With the fix:** both pass.

`test_permessage_deflate` is fully green (35 tests), as are the frames/protocol/extensions suites (288 tests). `ruff check`, `ruff format --check`, and `mypy` are clean on the changed files. The only failures in the full suite are pre-existing timing flakes in the `sync` tests (see #1716) and missing-`trio` import errors, both present on a clean baseline and unrelated to this change.
