### PR TITLE
Fix typos in comments

### DIFF
--- a/src/websockets/asyncio/connection.py
+++ b/src/websockets/asyncio/connection.py
@@ -823,7 +823,7 @@ class Connection(asyncio.Protocol):
                 # closing because ping(), via send_context(), waits for the
                 # connection to be closed before raising ConnectionClosed.
                 # However, connection_lost() cancels keepalive_task before
-                # it gets a chance to resume excuting.
+                # it gets a chance to resume executing.
                 pong_received = await self.ping()
                 if self.debug:
                     self.logger.debug("% sent keepalive ping")

--- a/src/websockets/datastructures.py
+++ b/src/websockets/datastructures.py
@@ -165,7 +165,7 @@ class Headers(MutableMapping[str, str]):
         """
         return iter(self._list)
 
-    # Internal menthods
+    # Internal methods
 
     def set_insecure(self, key: str, value: str) -> None:
         """


### PR DESCRIPTION
Fix two typos in inline comments found by codespell:

- `menthods` → `methods` in `src/websockets/datastructures.py` (line 168)
- `excuting` → `executing` in `src/websockets/asyncio/connection.py` (line 826)