### PR TITLE
Handle rejected handshakes cleanly in the threading server

### DIFF
--- a/src/websockets/sync/server.py
+++ b/src/websockets/sync/server.py
@@ -605,7 +605,12 @@ def serve(
                 connection.recv_events_thread.join()
                 return
 
-            assert connection.protocol.state is OPEN
+            if connection.protocol.state is not OPEN:
+                # process_request or process_response rejected the handshake.
+                connection.close_socket()
+                connection.recv_events_thread.join()
+                return
+
             try:
                 connection.start_keepalive()
                 handler(connection)

--- a/tests/sync/test_server.py
+++ b/tests/sync/test_server.py
@@ -151,29 +151,39 @@ class ServerTests(EvalShellMixin, unittest.TestCase):
         def handler(ws):
             self.fail("handler must not run")
 
-        with run_server(handler, process_request=process_request) as server:
-            with self.assertRaises(InvalidStatus) as raised:
-                with connect(get_uri(server)):
-                    self.fail("did not raise")
-            self.assertEqual(
-                str(raised.exception),
-                "server rejected WebSocket connection: HTTP 403",
-            )
+        with self.assertNoLogs("websockets", logging.ERROR):
+            with run_server(handler, process_request=process_request) as server:
+                with self.assertRaises(InvalidStatus) as raised:
+                    with connect(get_uri(server)):
+                        self.fail("did not raise")
+                self.assertEqual(
+                    str(raised.exception),
+                    "server rejected WebSocket connection: HTTP 403",
+                )
 
     def test_process_request_raises_exception(self):
         """Server returns an error if process_request raises an exception."""
 
         def process_request(ws, request):
-            raise RuntimeError
+            raise RuntimeError("BOOM")
 
-        with run_server(process_request=process_request) as server:
-            with self.assertRaises(InvalidStatus) as raised:
-                with connect(get_uri(server)):
-                    self.fail("did not raise")
-            self.assertEqual(
-                str(raised.exception),
-                "server rejected WebSocket connection: HTTP 500",
-            )
+        with self.assertLogs("websockets", logging.ERROR) as logs:
+            with run_server(process_request=process_request) as server:
+                with self.assertRaises(InvalidStatus) as raised:
+                    with connect(get_uri(server)):
+                        self.fail("did not raise")
+                self.assertEqual(
+                    str(raised.exception),
+                    "server rejected WebSocket connection: HTTP 500",
+                )
+        self.assertEqual(
+            [record.getMessage() for record in logs.records],
+            ["opening handshake failed"],
+        )
+        self.assertEqual(
+            [str(record.exc_info[1]) for record in logs.records],
+            ["BOOM"],
+        )
 
     def test_process_response_returns_none(self):
         """Server runs process_response but keeps the handshake response."""
@@ -213,16 +223,25 @@ class ServerTests(EvalShellMixin, unittest.TestCase):
         """Server returns an error if process_response raises an exception."""
 
         def process_response(ws, request, response):
-            raise RuntimeError
+            raise RuntimeError("BOOM")
 
-        with run_server(process_response=process_response) as server:
-            with self.assertRaises(InvalidStatus) as raised:
-                with connect(get_uri(server)):
-                    self.fail("did not raise")
-            self.assertEqual(
-                str(raised.exception),
-                "server rejected WebSocket connection: HTTP 500",
-            )
+        with self.assertLogs("websockets", logging.ERROR) as logs:
+            with run_server(process_response=process_response) as server:
+                with self.assertRaises(InvalidStatus) as raised:
+                    with connect(get_uri(server)):
+                        self.fail("did not raise")
+                self.assertEqual(
+                    str(raised.exception),
+                    "server rejected WebSocket connection: HTTP 500",
+                )
+        self.assertEqual(
+            [record.getMessage() for record in logs.records],
+            ["opening handshake failed"],
+        )
+        self.assertEqual(
+            [str(record.exc_info[1]) for record in logs.records],
+            ["BOOM"],
+        )
 
     def test_override_server(self):
         """Server can override Server header with server_header."""


### PR DESCRIPTION
## Summary

The threading server didn't handle a rejected opening handshake explicitly. When `process_request` or `process_response` returned an HTTP response, `handshake()` returned normally while the protocol state wasn't `OPEN`. The following assertion failed silently—or disappeared under `python -O`, allowing the handler to run on a closed connection and log `"connection handler failed"`.

## Fix

Replace the assertion with an explicit rejection path that closes the socket, joins the receive thread, and returns, mirroring the asyncio implementation.

## Tests / Verification

- Guarded `test_process_request_returns_response` with `assertNoLogs("websockets", logging.ERROR)`.
- Matched the asyncio tests by verifying the exact `"opening handshake failed"` error and exception for `process_request` and `process_response` failures.
- Official coverage environment: **2,258 tests passed**, 10 skipped, **100% coverage**.
- Ruff formatting and lint checks pass.
- Strict mypy checks pass.
- `python -O -m unittest tests.sync.test_server`: **50 tests passed**.

Refs #1513.

Disclosure: prepared with AI assistance; manually reviewed and verified locally.
