### PR TITLE
Fix rejected handshake cleanup in threading server

### DIFF
--- a/docs/project/changelog.rst
+++ b/docs/project/changelog.rst
@@ -59,6 +59,12 @@ New features
 * Added the ``--insecure`` option to the ``websockets`` CLI to disable TLS
   certificate validation.
 
+Bug fixes
+.........
+
+* Avoided an internal assertion when the :mod:`threading` server rejects an
+  opening handshake. (:issue:`1722`)
+
 .. _16.1:
 
 16.1

--- a/src/websockets/sync/server.py
+++ b/src/websockets/sync/server.py
@@ -615,7 +615,10 @@ def serve(
                 connection.recv_events_thread.join()
                 return
 
-            assert connection.protocol.state is OPEN
+            if connection.protocol.state is not OPEN:
+                connection.close_socket()
+                connection.recv_events_thread.join()
+                return
             try:
                 connection.start_keepalive()
                 handler(connection)

--- a/tests/sync/test_server.py
+++ b/tests/sync/test_server.py
@@ -3,6 +3,7 @@ import hmac
 import http
 import logging
 import socket
+import threading
 import time
 import unittest
 
@@ -145,20 +146,37 @@ class ServerTests(EvalShellMixin, unittest.TestCase):
     def test_process_request_returns_response(self):
         """Server aborts handshake if process_request returns a response."""
 
+        assertions = []
+
+        def trace(frame, event, arg):
+            if (
+                event == "exception"
+                and arg[0] is AssertionError
+                and frame.f_code.co_name == "conn_handler"
+            ):
+                assertions.append(arg[1])
+            return trace
+
         def process_request(ws, request):
             return ws.respond(http.HTTPStatus.FORBIDDEN, "Forbidden")
 
         def handler(ws):
             self.fail("handler must not run")
 
-        with run_server(handler, process_request=process_request) as server:
-            with self.assertRaises(InvalidStatus) as raised:
-                with connect(get_uri(server)):
-                    self.fail("did not raise")
-            self.assertEqual(
-                str(raised.exception),
-                "server rejected WebSocket connection: HTTP 403",
-            )
+        threading.settrace(trace)
+        try:
+            with run_server(handler, process_request=process_request) as server:
+                with self.assertRaises(InvalidStatus) as raised:
+                    with connect(get_uri(server)):
+                        self.fail("did not raise")
+                self.assertEqual(
+                    str(raised.exception),
+                    "server rejected WebSocket connection: HTTP 403",
+                )
+        finally:
+            threading.settrace(None)
+
+        self.assertEqual(assertions, [])
 
     def test_process_request_raises_exception(self):
         """Server returns an error if process_request raises an exception."""


### PR DESCRIPTION
The threading server treated an intentional HTTP rejection as a successful handshake and relied on an assertion to stop before the connection handler. That assertion was swallowed in normal mode and removed under `python -O`, where the handler ran on a closed connection.

This returns explicitly for a rejected handshake, closes and joins the receive thread, and adds a regression check that detects the internal assertion. Fixes #1722.
