### PR TITLE
Build all supported wheels on Linux, Windows, macOS.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,6 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          # GitHub Actions doesn't provide windows-latest-arm:
-          # https://github.com/actions/runner-images/issues/13885
-          - windows-11-arm
           - macOS-latest
     steps:
     - name: Check out repository

--- a/docs/project/changelog.rst
+++ b/docs/project/changelog.rst
@@ -90,7 +90,7 @@ Improvements
   reconnection attempts in :func:`~asyncio.client.connect`, beyond existing
   ``WEBSOCKETS_BACKOFF_*`` environment variables.
 
-* Added wheels for Windows ARM64.
+* Added wheels for Windows ARM64 and Linux i686.
 
 Bug fixes
 .........

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,13 +39,14 @@ websockets = "websockets.cli:main"
 [tool.cibuildwheel]
 enable = ["pypy"]
 
-# On a macOS runner, build Intel, Universal, and Apple Silicon wheels.
-[tool.cibuildwheel.macos]
-archs = ["x86_64", "universal2", "arm64"]
-
-# On an Linux Intel runner with QEMU installed, build Intel and ARM wheels.
 [tool.cibuildwheel.linux]
-archs = ["auto", "aarch64", "armv7l", "ppc64le", "riscv64", "s390x"]
+archs = ["x86_64", "aarch64", "i686", "armv7l", "ppc64le", "riscv64", "s390x"]
+
+[tool.cibuildwheel.macos]
+archs = ["arm64", "x86_64", "universal2"]
+
+[tool.cibuildwheel.windows]
+archs = ["AMD64", "ARM64", "x86"]
 
 [tool.codespell]
 skip = "docs/_build,docs/_static,*.svg"


### PR DESCRIPTION
Notably this adds 32 bits wheels on Linux and Windows.

Also use emulation to build ARM wheels on Windows. This is supported
because we don't run tests on every architecture and Python version.
