### PR TITLE
Avoid sending responses on closed TCP connections.

### DIFF
--- a/src/websockets/asyncio/client.py
+++ b/src/websockets/asyncio/client.py
@@ -93,12 +93,12 @@ class ClientConnection(Connection):
         Perform the opening handshake.
 
         """
+        self.request = self.protocol.connect()
+        if additional_headers is not None:
+            self.request.headers.update(additional_headers)
+        if user_agent_header is not None:
+            self.request.headers.setdefault("User-Agent", user_agent_header)
         async with self.send_context(expected_state=CONNECTING):
-            self.request = self.protocol.connect()
-            if additional_headers is not None:
-                self.request.headers.update(additional_headers)
-            if user_agent_header is not None:
-                self.request.headers.setdefault("User-Agent", user_agent_header)
             self.protocol.send_request(self.request)
 
         await asyncio.wait(

--- a/src/websockets/asyncio/server.py
+++ b/src/websockets/asyncio/server.py
@@ -137,69 +137,71 @@ class ServerConnection(Connection):
         )
 
         if self.request is not None:
-            async with self.send_context(expected_state=CONNECTING):
-                response = None
+            response = None
 
-                if process_request is not None:
-                    try:
-                        response = process_request(self, self.request)
-                        if isinstance(response, Awaitable):
-                            response = await response
-                    except Exception as exc:
-                        self.protocol.handshake_exc = exc
-                        self.logger.error("process_request failed", exc_info=True)
-                        response = self.protocol.reject(
-                            http.HTTPStatus.INTERNAL_SERVER_ERROR,
-                            (
-                                "Failed to open a WebSocket connection.\n"
-                                "See server log for more information.\n"
-                            ),
-                        )
-
-                if response is None:
-                    self.response = self.protocol.accept(self.request)
-                else:
-                    assert isinstance(response, Response)  # help mypy
-                    self.response = response
-
-                if server_header is not None:
-                    self.response.headers["Server"] = server_header
-
-                response = None
-
-                if process_response is not None:
-                    try:
-                        response = process_response(self, self.request, self.response)
-                        if isinstance(response, Awaitable):
-                            response = await response
-                    except Exception as exc:
-                        self.protocol.handshake_exc = exc
-                        self.logger.error("process_response failed", exc_info=True)
-                        response = self.protocol.reject(
-                            http.HTTPStatus.INTERNAL_SERVER_ERROR,
-                            (
-                                "Failed to open a WebSocket connection.\n"
-                                "See server log for more information.\n"
-                            ),
-                        )
-
-                if response is not None:
-                    assert isinstance(response, Response)  # help mypy
-                    self.response = response
-
-                # Reject the connection if the server started closing during the
-                # opening handshake. Don't yield before send_response() to avoid
-                # a race condition after checking if the server is closing.
-                if (
-                    self.response.status_code == http.HTTPStatus.SWITCHING_PROTOCOLS
-                    and not self.server.is_serving()
-                ):
-                    self.response = self.protocol.reject(
-                        http.HTTPStatus.SERVICE_UNAVAILABLE,
-                        "Server is shutting down.\n",
+            if process_request is not None:
+                try:
+                    response = process_request(self, self.request)
+                    if isinstance(response, Awaitable):
+                        response = await response
+                except Exception as exc:
+                    self.protocol.handshake_exc = exc
+                    self.logger.error("process_request failed", exc_info=True)
+                    response = self.protocol.reject(
+                        http.HTTPStatus.INTERNAL_SERVER_ERROR,
+                        (
+                            "Failed to open a WebSocket connection.\n"
+                            "See server log for more information.\n"
+                        ),
                     )
 
-                self.protocol.send_response(self.response)
+            if response is None:
+                self.response = self.protocol.accept(self.request)
+            else:
+                assert isinstance(response, Response)  # help mypy
+                self.response = response
+
+            if server_header is not None:
+                self.response.headers["Server"] = server_header
+
+            response = None
+
+            if process_response is not None:
+                try:
+                    response = process_response(self, self.request, self.response)
+                    if isinstance(response, Awaitable):
+                        response = await response
+                except Exception as exc:
+                    self.protocol.handshake_exc = exc
+                    self.logger.error("process_response failed", exc_info=True)
+                    response = self.protocol.reject(
+                        http.HTTPStatus.INTERNAL_SERVER_ERROR,
+                        (
+                            "Failed to open a WebSocket connection.\n"
+                            "See server log for more information.\n"
+                        ),
+                    )
+
+            if response is not None:
+                assert isinstance(response, Response)  # help mypy
+                self.response = response
+
+            # Reject the connection if the server started closing during the
+            # opening handshake. Don't yield before send_response() to avoid
+            # a race condition after checking if the server is closing.
+            if (
+                self.response.status_code == http.HTTPStatus.SWITCHING_PROTOCOLS
+                and not self.server.is_serving()
+            ):
+                self.response = self.protocol.reject(
+                    http.HTTPStatus.SERVICE_UNAVAILABLE,
+                    "Server is shutting down.\n",
+                )
+
+            # Don't respond if the connection was closed during the handshake.
+            if self.state is CONNECTING:
+                async with self.send_context(expected_state=CONNECTING):
+                    self.protocol.send_response(self.response)
 
     def process_event(self, event: Event) -> None:
         """

--- a/src/websockets/sync/client.py
+++ b/src/websockets/sync/client.py
@@ -84,12 +84,12 @@ class ClientConnection(Connection):
         Perform the opening handshake.
 
         """
+        self.request = self.protocol.connect()
+        if additional_headers is not None:
+            self.request.headers.update(additional_headers)
+        if user_agent_header is not None:
+            self.request.headers.setdefault("User-Agent", user_agent_header)
         with self.send_context(expected_state=CONNECTING):
-            self.request = self.protocol.connect()
-            if additional_headers is not None:
-                self.request.headers.update(additional_headers)
-            if user_agent_header is not None:
-                self.request.headers.setdefault("User-Agent", user_agent_header)
             self.protocol.send_request(self.request)
 
         if not self.response_rcvd.wait(timeout):

--- a/src/websockets/sync/server.py
+++ b/src/websockets/sync/server.py
@@ -144,63 +144,65 @@ class ServerConnection(Connection):
             raise TimeoutError("timed out while waiting for handshake request")
 
         if self.request is not None:
-            with self.send_context(expected_state=CONNECTING):
-                response = None
+            response = None
 
-                if process_request is not None:
-                    try:
-                        response = process_request(self, self.request)
-                    except Exception as exc:
-                        self.protocol.handshake_exc = exc
-                        self.logger.error("process_request failed", exc_info=True)
-                        response = self.protocol.reject(
-                            http.HTTPStatus.INTERNAL_SERVER_ERROR,
-                            (
-                                "Failed to open a WebSocket connection.\n"
-                                "See server log for more information.\n"
-                            ),
-                        )
-
-                if response is None:
-                    self.response = self.protocol.accept(self.request)
-                else:
-                    self.response = response
-
-                if server_header is not None:
-                    self.response.headers["Server"] = server_header
-
-                response = None
-
-                if process_response is not None:
-                    try:
-                        response = process_response(self, self.request, self.response)
-                    except Exception as exc:
-                        self.protocol.handshake_exc = exc
-                        self.logger.error("process_response failed", exc_info=True)
-                        response = self.protocol.reject(
-                            http.HTTPStatus.INTERNAL_SERVER_ERROR,
-                            (
-                                "Failed to open a WebSocket connection.\n"
-                                "See server log for more information.\n"
-                            ),
-                        )
-
-                    if response is not None:
-                        self.response = response
-
-                # Reject the connection if the server started closing during the
-                # opening handshake. shutdown() runs a loop to catch cases where
-                # the server shuts down between this check and send_response().
-                if (
-                    self.response.status_code == http.HTTPStatus.SWITCHING_PROTOCOLS
-                    and self.server.socket_closed.is_set()
-                ):
-                    self.response = self.protocol.reject(
-                        http.HTTPStatus.SERVICE_UNAVAILABLE,
-                        "Server is shutting down.\n",
+            if process_request is not None:
+                try:
+                    response = process_request(self, self.request)
+                except Exception as exc:
+                    self.protocol.handshake_exc = exc
+                    self.logger.error("process_request failed", exc_info=True)
+                    response = self.protocol.reject(
+                        http.HTTPStatus.INTERNAL_SERVER_ERROR,
+                        (
+                            "Failed to open a WebSocket connection.\n"
+                            "See server log for more information.\n"
+                        ),
                     )
 
-                self.protocol.send_response(self.response)
+            if response is None:
+                self.response = self.protocol.accept(self.request)
+            else:
+                self.response = response
+
+            if server_header is not None:
+                self.response.headers["Server"] = server_header
+
+            response = None
+
+            if process_response is not None:
+                try:
+                    response = process_response(self, self.request, self.response)
+                except Exception as exc:
+                    self.protocol.handshake_exc = exc
+                    self.logger.error("process_response failed", exc_info=True)
+                    response = self.protocol.reject(
+                        http.HTTPStatus.INTERNAL_SERVER_ERROR,
+                        (
+                            "Failed to open a WebSocket connection.\n"
+                            "See server log for more information.\n"
+                        ),
+                    )
+
+                if response is not None:
+                    self.response = response
+
+            # Reject the connection if the server started closing during the
+            # opening handshake. shutdown() runs a loop to catch cases where
+            # the server shuts down between this check and send_response().
+            if (
+                self.response.status_code == http.HTTPStatus.SWITCHING_PROTOCOLS
+                and self.server.socket_closed.is_set()
+            ):
+                self.response = self.protocol.reject(
+                    http.HTTPStatus.SERVICE_UNAVAILABLE,
+                    "Server is shutting down.\n",
+                )
+
+            # Don't respond if the connection was closed during the handshake.
+            if self.state is CONNECTING:
+                with self.send_context(expected_state=CONNECTING):
+                    self.protocol.send_response(self.response)
 
     def process_event(self, event: Event) -> None:
         """

--- a/src/websockets/trio/client.py
+++ b/src/websockets/trio/client.py
@@ -98,12 +98,12 @@ class ClientConnection(Connection):
         Perform the opening handshake.
 
         """
+        self.request = self.protocol.connect()
+        if additional_headers is not None:
+            self.request.headers.update(additional_headers)
+        if user_agent_header is not None:
+            self.request.headers.setdefault("User-Agent", user_agent_header)
         async with self.send_context(expected_state=CONNECTING):
-            self.request = self.protocol.connect()
-            if additional_headers is not None:
-                self.request.headers.update(additional_headers)
-            if user_agent_header is not None:
-                self.request.headers.setdefault("User-Agent", user_agent_header)
             self.protocol.send_request(self.request)
 
         await race_events(self.response_rcvd, self.stream_closed)

--- a/src/websockets/trio/server.py
+++ b/src/websockets/trio/server.py
@@ -136,69 +136,71 @@ class ServerConnection(Connection):
         await race_events(self.request_rcvd, self.stream_closed)
 
         if self.request is not None:
-            async with self.send_context(expected_state=CONNECTING):
-                response = None
+            response = None
 
-                if process_request is not None:
-                    try:
-                        response = process_request(self, self.request)
-                        if isinstance(response, Awaitable):
-                            response = await response
-                    except Exception as exc:
-                        self.protocol.handshake_exc = exc
-                        self.logger.error("process_request failed", exc_info=True)
-                        response = self.protocol.reject(
-                            http.HTTPStatus.INTERNAL_SERVER_ERROR,
-                            (
-                                "Failed to open a WebSocket connection.\n"
-                                "See server log for more information.\n"
-                            ),
-                        )
-
-                if response is None:
-                    self.response = self.protocol.accept(self.request)
-                else:
-                    assert isinstance(response, Response)  # help mypy
-                    self.response = response
-
-                if server_header is not None:
-                    self.response.headers["Server"] = server_header
-
-                response = None
-
-                if process_response is not None:
-                    try:
-                        response = process_response(self, self.request, self.response)
-                        if isinstance(response, Awaitable):
-                            response = await response
-                    except Exception as exc:
-                        self.protocol.handshake_exc = exc
-                        self.logger.error("process_response failed", exc_info=True)
-                        response = self.protocol.reject(
-                            http.HTTPStatus.INTERNAL_SERVER_ERROR,
-                            (
-                                "Failed to open a WebSocket connection.\n"
-                                "See server log for more information.\n"
-                            ),
-                        )
-
-                if response is not None:
-                    assert isinstance(response, Response)  # help mypy
-                    self.response = response
-
-                # Reject the connection if the server started closing during the
-                # opening handshake. Don't yield before send_response() to avoid
-                # a race condition after checking if the server is closing.
-                if (
-                    self.response.status_code == http.HTTPStatus.SWITCHING_PROTOCOLS
-                    and self.server.closing
-                ):
-                    self.response = self.protocol.reject(
-                        http.HTTPStatus.SERVICE_UNAVAILABLE,
-                        "Server is shutting down.\n",
+            if process_request is not None:
+                try:
+                    response = process_request(self, self.request)
+                    if isinstance(response, Awaitable):
+                        response = await response
+                except Exception as exc:
+                    self.protocol.handshake_exc = exc
+                    self.logger.error("process_request failed", exc_info=True)
+                    response = self.protocol.reject(
+                        http.HTTPStatus.INTERNAL_SERVER_ERROR,
+                        (
+                            "Failed to open a WebSocket connection.\n"
+                            "See server log for more information.\n"
+                        ),
                     )
 
-                self.protocol.send_response(self.response)
+            if response is None:
+                self.response = self.protocol.accept(self.request)
+            else:
+                assert isinstance(response, Response)  # help mypy
+                self.response = response
+
+            if server_header is not None:
+                self.response.headers["Server"] = server_header
+
+            response = None
+
+            if process_response is not None:
+                try:
+                    response = process_response(self, self.request, self.response)
+                    if isinstance(response, Awaitable):
+                        response = await response
+                except Exception as exc:
+                    self.protocol.handshake_exc = exc
+                    self.logger.error("process_response failed", exc_info=True)
+                    response = self.protocol.reject(
+                        http.HTTPStatus.INTERNAL_SERVER_ERROR,
+                        (
+                            "Failed to open a WebSocket connection.\n"
+                            "See server log for more information.\n"
+                        ),
+                    )
+
+            if response is not None:
+                assert isinstance(response, Response)  # help mypy
+                self.response = response
+
+            # Reject the connection if the server started closing during the
+            # opening handshake. Don't yield before send_response() to avoid
+            # a race condition after checking if the server is closing.
+            if (
+                self.response.status_code == http.HTTPStatus.SWITCHING_PROTOCOLS
+                and self.server.closing
+            ):
+                self.response = self.protocol.reject(
+                    http.HTTPStatus.SERVICE_UNAVAILABLE,
+                    "Server is shutting down.\n",
+                )
+
+            # Don't respond if the connection was closed during the handshake.
+            if self.state is CONNECTING:
+                async with self.send_context(expected_state=CONNECTING):
+                    self.protocol.send_response(self.response)
 
     def process_event(self, event: Event) -> None:
         """

--- a/tests/asyncio/test_server.py
+++ b/tests/asyncio/test_server.py
@@ -11,6 +11,7 @@ from websockets.asyncio.server import *
 from websockets.exceptions import (
     ConnectionClosedError,
     ConnectionClosedOK,
+    InvalidHandshake,
     InvalidStatus,
     NegotiationError,
 )
@@ -416,7 +417,7 @@ class ServerTests(EvalShellMixin, LoggingTestCase, unittest.IsolatedAsyncioTestC
                 "server rejected WebSocket connection: HTTP 400",
             )
 
-    async def test_timeout_during_handshake(self):
+    async def test_timeout_before_handshake_request(self):
         """Server times out before receiving handshake request from client."""
         with self.assertLogs("websockets", logging.DEBUG) as logs:
             async with serve(*args, open_timeout=MS) as server:
@@ -433,7 +434,7 @@ class ServerTests(EvalShellMixin, LoggingTestCase, unittest.IsolatedAsyncioTestC
             "connection closed while reading HTTP request line",
         )
 
-    async def test_connection_closed_during_handshake(self):
+    async def test_connection_closed_before_handshake_request(self):
         """Server reads EOF before receiving handshake request from client."""
         with self.assertLogs("websockets", logging.DEBUG) as logs:
             async with serve(*args) as server:
@@ -445,6 +446,19 @@ class ServerTests(EvalShellMixin, LoggingTestCase, unittest.IsolatedAsyncioTestC
             "! no valid HTTP request",
             "connection closed while reading HTTP request line",
         )
+
+    async def test_connection_closed_before_handshake_response(self):
+        """Server reads EOF before sending handshake response to client."""
+
+        async def process_request(ws, _request):
+            ws.transport.close()
+            await asyncio.sleep(0)
+
+        with self.assertNoLogs("websockets", logging.ERROR):
+            async with serve(*args, process_request=process_request) as server:
+                with self.assertRaises(InvalidHandshake):
+                    async with connect(get_uri(server)):
+                        self.fail("did not raise")
 
     async def test_junk_handshake_request(self):
         """Server closes the connection when receiving non-HTTP request from client."""

--- a/tests/sync/test_server.py
+++ b/tests/sync/test_server.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from websockets.exceptions import (
     ConnectionClosedError,
     ConnectionClosedOK,
+    InvalidHandshake,
     InvalidStatus,
     NegotiationError,
 )
@@ -315,7 +316,7 @@ class ServerTests(EvalShellMixin, LoggingTestCase, unittest.TestCase):
                 "server rejected WebSocket connection: HTTP 400",
             )
 
-    def test_timeout_during_handshake(self):
+    def test_timeout_before_handshake_request(self):
         """Server times out before receiving handshake request from client."""
         with self.assertLogs("websockets", logging.DEBUG) as logs:
             with run_server(open_timeout=MS) as server:
@@ -329,7 +330,7 @@ class ServerTests(EvalShellMixin, LoggingTestCase, unittest.TestCase):
             "connection closed while reading HTTP request line",
         )
 
-    def test_connection_closed_during_handshake(self):
+    def test_connection_closed_before_handshake_request(self):
         """Server reads EOF before receiving handshake request from client."""
         with self.assertLogs("websockets", logging.DEBUG) as logs:
             with run_server() as server:
@@ -342,6 +343,19 @@ class ServerTests(EvalShellMixin, LoggingTestCase, unittest.TestCase):
             "! no valid HTTP request",
             "connection closed while reading HTTP request line",
         )
+
+    def test_connection_closed_before_handshake_response_sync(self):
+        """Server reads EOF before sending handshake response to client."""
+
+        def process_request(ws, _request):
+            ws.socket.shutdown(socket.SHUT_RDWR)
+            ws.socket.close()
+
+        with self.assertNoLogs("websockets", logging.ERROR):
+            with run_server(process_request=process_request) as server:
+                with self.assertRaises(InvalidHandshake):
+                    with connect(get_uri(server)):
+                        self.fail("did not raise")
 
     def test_junk_handshake_request(self):
         """Server closes the connection when receiving non-HTTP request from client."""

--- a/tests/trio/test_server.py
+++ b/tests/trio/test_server.py
@@ -8,6 +8,7 @@ import trio
 from websockets.exceptions import (
     ConnectionClosedError,
     ConnectionClosedOK,
+    InvalidHandshake,
     InvalidStatus,
     NegotiationError,
 )
@@ -411,7 +412,7 @@ class ServerTests(EvalShellMixin, LoggingTestCase, IsolatedTrioTestCase):
                 "server rejected WebSocket connection: HTTP 400",
             )
 
-    async def test_timeout_during_handshake(self):
+    async def test_timeout_before_handshake_request(self):
         """Server times out before receiving handshake request from client."""
         with self.assertLogs("websockets", logging.DEBUG) as logs:
             async with run_server(open_timeout=MS) as server:
@@ -428,7 +429,7 @@ class ServerTests(EvalShellMixin, LoggingTestCase, IsolatedTrioTestCase):
             "connection closed while reading HTTP request line",
         )
 
-    async def test_connection_closed_during_handshake(self):
+    async def test_connection_closed_before_handshake_request(self):
         """Server reads EOF before receiving handshake request from client."""
         with self.assertLogs("websockets", logging.DEBUG) as logs:
             async with run_server() as server:
@@ -440,6 +441,19 @@ class ServerTests(EvalShellMixin, LoggingTestCase, IsolatedTrioTestCase):
             "! no valid HTTP request",
             "connection closed while reading HTTP request line",
         )
+
+    async def test_connection_closed_before_handshake_response(self):
+        """Server reads EOF before sending handshake response to client."""
+
+        async def process_request(ws, _request):
+            await ws.stream.aclose()
+            await trio.testing.wait_all_tasks_blocked()
+
+        with self.assertNoLogs("websockets", logging.ERROR):
+            async with run_server(process_request=process_request) as server:
+                with self.assertRaises(InvalidHandshake):
+                    async with connect(get_uri(server)):
+                        self.fail("did not raise")
 
     async def test_junk_handshake_request(self):
         """Server closes the connection when receiving non-HTTP request from client."""


### PR DESCRIPTION
This could result in an unexpected internal error.
