### PR TITLE
Adjust SSL certificate-verification error strings for AWS-LC compat

### DIFF
--- a/tests/asyncio/test_client.py
+++ b/tests/asyncio/test_client.py
@@ -554,7 +554,7 @@ class SecureClientTests(unittest.IsolatedAsyncioTestCase):
                 async with connect(get_uri(server)):
                     self.fail("did not raise")
             self.assertIn(
-                "certificate verify failed: self signed certificate",
+                "self signed certificate",
                 str(raised.exception).replace("-", " "),
             )
 
@@ -568,7 +568,7 @@ class SecureClientTests(unittest.IsolatedAsyncioTestCase):
                 ):
                     self.fail("did not raise")
             self.assertIn(
-                "certificate verify failed: Hostname mismatch",
+                "Hostname mismatch",
                 str(raised.exception),
             )
 
@@ -878,7 +878,7 @@ class HTTPProxyClientTests(ProxyMixin, unittest.IsolatedAsyncioTestCase):
             async with connect("wss://example.com/"):
                 self.fail("did not raise")
         self.assertIn(
-            "certificate verify failed: unable to get local issuer certificate",
+            "unable to get local issuer certificate",
             str(raised.exception),
         )
 
@@ -891,7 +891,7 @@ class HTTPProxyClientTests(ProxyMixin, unittest.IsolatedAsyncioTestCase):
                 async with connect(get_uri(server), proxy_ssl=self.proxy_context):
                     self.fail("did not raise")
         self.assertIn(
-            "certificate verify failed: self signed certificate",
+            "self signed certificate",
             str(raised.exception).replace("-", " "),
         )
         self.assertNumFlows(1)

--- a/tests/sync/test_client.py
+++ b/tests/sync/test_client.py
@@ -328,7 +328,7 @@ class SecureClientTests(unittest.TestCase):
                 with connect(get_uri(server)):
                     self.fail("did not raise")
             self.assertIn(
-                "certificate verify failed: self signed certificate",
+                "self signed certificate",
                 str(raised.exception).replace("-", " "),
             )
 
@@ -342,7 +342,7 @@ class SecureClientTests(unittest.TestCase):
                 ):
                     self.fail("did not raise")
             self.assertIn(
-                "certificate verify failed: Hostname mismatch",
+                "Hostname mismatch",
                 str(raised.exception),
             )
 
@@ -615,7 +615,7 @@ class HTTPProxyClientTests(ProxyMixin, unittest.IsolatedAsyncioTestCase):
             with connect("wss://example.com/"):
                 self.fail("did not raise")
         self.assertIn(
-            "certificate verify failed: unable to get local issuer certificate",
+            "unable to get local issuer certificate",
             str(raised.exception),
         )
         self.assertNumFlows(0)
@@ -629,7 +629,7 @@ class HTTPProxyClientTests(ProxyMixin, unittest.IsolatedAsyncioTestCase):
                 with connect(get_uri(server), proxy_ssl=self.proxy_context):
                     self.fail("did not raise")
         self.assertIn(
-            "certificate verify failed: self signed certificate",
+            "self signed certificate",
             str(raised.exception).replace("-", " "),
         )
         self.assertNumFlows(1)

--- a/tests/trio/test_client.py
+++ b/tests/trio/test_client.py
@@ -567,7 +567,7 @@ class SecureClientTests(IsolatedTrioTestCase):
                 ssl.SSLCertVerificationError,
             )
             self.assertIn(
-                "certificate verify failed: self signed certificate",
+                "self signed certificate",
                 str(raised.exception.__cause__).replace("-", " "),
             )
 
@@ -587,7 +587,7 @@ class SecureClientTests(IsolatedTrioTestCase):
                 ssl.SSLCertVerificationError,
             )
             self.assertIn(
-                "certificate verify failed: Hostname mismatch",
+                "Hostname mismatch",
                 str(raised.exception.__cause__),
             )
 
@@ -884,7 +884,7 @@ class HTTPProxyClientTests(ProxyMixin, IsolatedTrioTestCase):
                 self.fail("did not raise")
         self.assertIsInstance(raised.exception.__cause__, ssl.SSLCertVerificationError)
         self.assertIn(
-            "certificate verify failed: unable to get local issuer certificate",
+            "unable to get local issuer certificate",
             str(raised.exception.__cause__),
         )
 
@@ -900,7 +900,7 @@ class HTTPProxyClientTests(ProxyMixin, IsolatedTrioTestCase):
                     self.fail("did not raise")
         self.assertIsInstance(raised.exception.__cause__, ssl.SSLCertVerificationError)
         self.assertIn(
-            "certificate verify failed: self signed certificate",
+            "self signed certificate",
             str(raised.exception.__cause__).replace("-", " "),
         )
         self.assertNumFlows(1)


### PR DESCRIPTION
AWS-LC ssl.SSLCertVerificationError message differs from OpenSSL:
- `OpenSSL`:  "certificate verify failed: self signed certificate"
- `AWS-LC`:   "[SSL: CERTIFICATE_VERIFY_FAILED] CERTIFICATE_VERIFY_FAILED: self signed certificate (_ssl.c:1082)"

By adjusting the text being looked for to be the common substrings, the tests work when Python is built with the AWS-LC cryptographic library instead of OpenSSL.