### PR TITLE
Accept pathlib.Path objects in path arguments.

### DIFF
--- a/docs/project/changelog.rst
+++ b/docs/project/changelog.rst
@@ -50,6 +50,9 @@ Improvements
 
 * Connections are now garbage collected immediately once closed.
 
+* :func:`~sync.client.unix_connect` and :func:`~sync.server.unix_serve` now accept
+  path-like objects, such as :class:`pathlib.Path`, in the ``path`` argument.
+
 .. _17.0.1:
 
 17.0.1

--- a/docs/reference/types.rst
+++ b/docs/reference/types.rst
@@ -15,6 +15,8 @@ Types
 
 .. autodata:: LoggerLike
 
+.. autodata:: PathLike
+
 .. autodata:: StatusLike
 
 .. autodata:: Origin

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -25,6 +25,7 @@ dev
 django
 Dockerfile
 dyno
+filesystem
 formatter
 fractalideas
 github

--- a/src/websockets/asyncio/client.py
+++ b/src/websockets/asyncio/client.py
@@ -27,7 +27,7 @@ from ..http11 import USER_AGENT, Response
 from ..protocol import CONNECTING, Event
 from ..proxy import Proxy, get_proxy, parse_proxy, prepare_connect_request
 from ..streams import StreamReader
-from ..typing import LoggerLike, Origin, Subprotocol
+from ..typing import LoggerLike, Origin, PathLike, Subprotocol
 from ..uri import WebSocketURI, parse_uri
 from .connection import Connection
 
@@ -630,7 +630,7 @@ class connect:
 
 
 def unix_connect(
-    path: str | None = None,
+    path: PathLike | None = None,
     uri: str | None = None,
     **kwargs: Any,
 ) -> connect:

--- a/src/websockets/asyncio/router.py
+++ b/src/websockets/asyncio/router.py
@@ -6,6 +6,7 @@ import urllib.parse
 from typing import Any, Awaitable, Callable, Literal
 
 from ..http11 import Request, Response
+from ..typing import PathLike
 from .server import Server, ServerConnection, serve
 
 
@@ -30,7 +31,7 @@ except ImportError:
 
     def unix_route(
         url_map: Map,
-        path: str | None = None,
+        path: PathLike | None = None,
         **kwargs: Any,
     ) -> Server:
         raise ImportError("unix_route() requires werkzeug")
@@ -155,7 +156,7 @@ else:
 
     def unix_route(
         url_map: Map,
-        path: str | None = None,
+        path: PathLike | None = None,
         **kwargs: Any,
     ) -> Server:
         """

--- a/src/websockets/asyncio/server.py
+++ b/src/websockets/asyncio/server.py
@@ -22,7 +22,7 @@ from ..headers import (
 from ..http11 import SERVER, Request, Response
 from ..protocol import CONNECTING, OPEN, Event
 from ..server import ServerProtocol
-from ..typing import LoggerLike, Origin, StatusLike, Subprotocol
+from ..typing import LoggerLike, Origin, PathLike, StatusLike, Subprotocol
 from ..utils import get_socket_name
 from .connection import Connection, broadcast
 
@@ -769,7 +769,7 @@ def serve(
 
 def unix_serve(
     handler: Callable[[ServerConnection], Awaitable[None]],
-    path: str | None = None,
+    path: PathLike | None = None,
     **kwargs: Any,
 ) -> Server:
     """

--- a/src/websockets/sync/client.py
+++ b/src/websockets/sync/client.py
@@ -463,6 +463,7 @@ class reconnect:
                     f"cannot follow cross-origin redirect to {new_uri} "
                     f"with a Unix socket"
                 )
+
             # Cross-origin redirects when host and port are overridden are ill-defined.
             if self.open_socket_kwargs.get("address") is not None:
                 return ValueError(

--- a/src/websockets/sync/client.py
+++ b/src/websockets/sync/client.py
@@ -29,7 +29,7 @@ from ..http11 import USER_AGENT, Response
 from ..protocol import CONNECTING, Event
 from ..proxy import Proxy, get_proxy, parse_proxy, prepare_connect_request
 from ..streams import StreamReader
-from ..typing import BytesLike, LoggerLike, Origin, Subprotocol
+from ..typing import BytesLike, LoggerLike, Origin, PathLike, Subprotocol
 from ..uri import WebSocketURI, parse_uri
 from .connection import Connection
 from .utils import Deadline
@@ -308,7 +308,7 @@ class reconnect:
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             try:
                 sock.settimeout(deadline.timeout())
-                sock.connect(kwargs.pop("path"))
+                sock.connect(os.fspath(kwargs.pop("path")))
             except Exception:
                 sock.close()
                 raise
@@ -821,7 +821,7 @@ def connect(
 
 
 def unix_reconnect(
-    path: str | None = None,
+    path: PathLike | None = None,
     uri: str | None = None,
     **kwargs: Any,
 ) -> reconnect:
@@ -849,7 +849,7 @@ def unix_reconnect(
 
 @overload
 def unix_connect(
-    path: str | None = ...,
+    path: PathLike | None = ...,
     uri: str | None = ...,
     *,
     legacy: Literal[True] | None = ...,
@@ -859,7 +859,7 @@ def unix_connect(
 
 @overload
 def unix_connect(
-    path: str | None = ...,
+    path: PathLike | None = ...,
     uri: str | None = ...,
     *,
     legacy: Literal[False],
@@ -868,7 +868,7 @@ def unix_connect(
 
 
 def unix_connect(
-    path: str | None = None,
+    path: PathLike | None = None,
     uri: str | None = None,
     *,
     legacy: bool | None = None,

--- a/src/websockets/sync/router.py
+++ b/src/websockets/sync/router.py
@@ -6,6 +6,7 @@ import urllib.parse
 from typing import Any, Callable, Literal
 
 from ..http11 import Request, Response
+from ..typing import PathLike
 from .server import Server, ServerConnection, serve
 
 
@@ -30,7 +31,7 @@ except ImportError:
 
     def unix_route(
         url_map: Map,
-        path: str | None = None,
+        path: PathLike | None = None,
         **kwargs: Any,
     ) -> Server:
         raise ImportError("unix_route() requires werkzeug")
@@ -141,7 +142,7 @@ else:
 
     def unix_route(
         url_map: Map,
-        path: str | None = None,
+        path: PathLike | None = None,
         **kwargs: Any,
     ) -> Server:
         """

--- a/src/websockets/sync/server.py
+++ b/src/websockets/sync/server.py
@@ -4,6 +4,7 @@ import concurrent.futures
 import hmac
 import http
 import logging
+import os
 import re
 import selectors
 import socket
@@ -28,7 +29,7 @@ from ..headers import (
 from ..http11 import SERVER, Request, Response
 from ..protocol import CONNECTING, OPEN, Event
 from ..server import ServerProtocol
-from ..typing import LoggerLike, Origin, StatusLike, Subprotocol
+from ..typing import LoggerLike, Origin, PathLike, StatusLike, Subprotocol
 from ..utils import get_socket_name
 from .connection import Connection, broadcast
 from .utils import Deadline
@@ -645,7 +646,7 @@ def serve(
             if path is None:
                 raise ValueError("missing path argument")
             kwargs.setdefault("family", socket.AF_UNIX)
-            sock = socket.create_server(path, **kwargs)
+            sock = socket.create_server(os.fspath(path), **kwargs)
         else:
             sock = socket.create_server((host, port), **kwargs)
     else:
@@ -793,7 +794,7 @@ def serve(
 
 def unix_serve(
     handler: Callable[[ServerConnection], None],
-    path: str | None = None,
+    path: PathLike | None = None,
     **kwargs: Any,
 ) -> Server:
     """

--- a/src/websockets/trio/client.py
+++ b/src/websockets/trio/client.py
@@ -27,7 +27,7 @@ from ..http11 import USER_AGENT, Response
 from ..protocol import CONNECTING, Event
 from ..proxy import Proxy, get_proxy, parse_proxy, prepare_connect_request
 from ..streams import StreamReader
-from ..typing import LoggerLike, Origin, Subprotocol
+from ..typing import LoggerLike, Origin, PathLike, Subprotocol
 from ..uri import WebSocketURI, parse_uri
 from .connection import Connection
 from .utils import race_events
@@ -640,7 +640,7 @@ class connect:
 
 
 def unix_connect(
-    path: str | None = None,
+    path: PathLike | None = None,
     uri: str | None = None,
     **kwargs: Any,
 ) -> connect:

--- a/src/websockets/trio/client.py
+++ b/src/websockets/trio/client.py
@@ -482,6 +482,7 @@ class connect:
                     f"cannot follow cross-origin redirect to {new_uri} "
                     f"with a Unix socket"
                 )
+
             # Cross-origin redirects when host and port are overridden are ill-defined.
             if (
                 self.open_tcp_stream_kwargs.get("host") is not None

--- a/src/websockets/typing.py
+++ b/src/websockets/typing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import http
 import logging
+import os
 from typing import Any, NewType, Sequence
 
 
@@ -36,10 +37,11 @@ DataLike = str | bytes | bytearray | memoryview
 LoggerLike = logging.Logger | logging.LoggerAdapter[Any]
 """Types accepted where a :class:`~logging.Logger` is expected."""
 
+PathLike = str | bytes | os.PathLike[str] | os.PathLike[bytes]
+"""Types accepted where a filesystem path is expected."""
 
 StatusLike = http.HTTPStatus | int
-"""
-Types accepted where an :class:`~http.HTTPStatus` is expected."""
+"""Types accepted where an :class:`~http.HTTPStatus` is expected."""
 
 
 Origin = NewType("Origin", str)

--- a/tests/asyncio/test_client.py
+++ b/tests/asyncio/test_client.py
@@ -3,6 +3,7 @@ import contextlib
 import http
 import logging
 import os
+import pathlib
 import socket
 import ssl
 import sys
@@ -992,6 +993,13 @@ class UnixClientTests(unittest.IsolatedAsyncioTestCase):
                 ) as client:
                     ssl_object = client.transport.get_extra_info("ssl_object")
                     self.assertEqual(ssl_object.server_hostname, "overridden")
+
+    async def test_pathlib_path(self):
+        """Client accepts a pathlib.Path object as the path argument."""
+        with temp_unix_socket_path() as path:
+            async with unix_serve(handler, path):
+                async with unix_connect(pathlib.Path(path)) as client:
+                    self.assertEqual(client.protocol.state.name, "OPEN")
 
     async def test_non_existing_path(self):
         """Client attempts to connect to a non-existing Unix socket path."""

--- a/tests/asyncio/test_server.py
+++ b/tests/asyncio/test_server.py
@@ -3,6 +3,7 @@ import dataclasses
 import hmac
 import http
 import logging
+import pathlib
 import socket
 import unittest
 
@@ -739,6 +740,13 @@ class UnixServerTests(EvalShellMixin, unittest.IsolatedAsyncioTestCase):
         """Server receives connection from client over a Unix socket."""
         with temp_unix_socket_path() as path:
             async with unix_serve(handler, path):
+                async with unix_connect(path) as client:
+                    await self.assertEval(client, "ws.protocol.state.name", "OPEN")
+
+    async def test_pathlib_path(self):
+        """Server accepts a pathlib.Path object as the path argument."""
+        with temp_unix_socket_path() as path:
+            async with unix_serve(handler, pathlib.Path(path)):
                 async with unix_connect(path) as client:
                     await self.assertEval(client, "ws.protocol.state.name", "OPEN")
 

--- a/tests/sync/test_client.py
+++ b/tests/sync/test_client.py
@@ -2,6 +2,7 @@ import contextlib
 import http
 import logging
 import os
+import pathlib
 import socket
 import socketserver
 import ssl
@@ -1032,6 +1033,13 @@ class UnixClientTests(unittest.TestCase):
                     path, ssl=CLIENT_CONTEXT, uri="wss://overridden/"
                 ) as client:
                     self.assertEqual(client.socket.server_hostname, "overridden")
+
+    def test_pathlib_path(self):
+        """Client accepts a pathlib.Path object as the path argument."""
+        with temp_unix_socket_path() as path:
+            with run_unix_server(path):
+                with unix_connect(pathlib.Path(path)) as client:
+                    self.assertEqual(client.protocol.state.name, "OPEN")
 
     def test_non_existing_path(self):
         """Client attempts to connect to a non-existing Unix socket path."""

--- a/tests/sync/test_server.py
+++ b/tests/sync/test_server.py
@@ -2,6 +2,7 @@ import dataclasses
 import hmac
 import http
 import logging
+import pathlib
 import socket
 import threading
 import time
@@ -521,6 +522,13 @@ class UnixServerTests(EvalShellMixin, unittest.TestCase):
         """Server receives connection from client over a Unix socket."""
         with temp_unix_socket_path() as path:
             with run_unix_server(path):
+                with unix_connect(path) as client:
+                    self.assertEval(client, "ws.protocol.state.name", "OPEN")
+
+    def test_pathlib_path(self):
+        """Server accepts a pathlib.Path object as the path argument."""
+        with temp_unix_socket_path() as path:
+            with run_unix_server(pathlib.Path(path)):
                 with unix_connect(path) as client:
                     self.assertEval(client, "ws.protocol.state.name", "OPEN")
 

--- a/tests/trio/test_client.py
+++ b/tests/trio/test_client.py
@@ -985,7 +985,6 @@ class UnixClientTests(IsolatedTrioTestCase):
             with run_unix_server(path):
                 async with unix_connect(pathlib.Path(path)) as client:
                     self.assertEqual(client.protocol.state.name, "OPEN")
-                self.assertEqual(client.protocol.state.name, "CLOSED")
 
     async def test_non_existing_path(self):
         """Client attempts to connect to a non-existing Unix socket path."""

--- a/tests/trio/test_client.py
+++ b/tests/trio/test_client.py
@@ -2,6 +2,7 @@ import contextlib
 import http
 import logging
 import os
+import pathlib
 import socket
 import ssl
 import sys
@@ -977,6 +978,14 @@ class UnixClientTests(IsolatedTrioTestCase):
                 ) as client:
                     ssl_object = client.stream._ssl_object
                     self.assertEqual(ssl_object.server_hostname, "overridden")
+
+    async def test_pathlib_path(self):
+        """Client accepts a pathlib.Path object as the path argument."""
+        with temp_unix_socket_path() as path:
+            with run_unix_server(path):
+                async with unix_connect(pathlib.Path(path)) as client:
+                    self.assertEqual(client.protocol.state.name, "OPEN")
+                self.assertEqual(client.protocol.state.name, "CLOSED")
 
     async def test_non_existing_path(self):
         """Client attempts to connect to a non-existing Unix socket path."""


### PR DESCRIPTION
This was already working in the asyncio and trio implementations because
we're relying on high-level helpers that already support such objects.
Changes were only necessary for the threading implementation.
